### PR TITLE
Fjern ubrukte dependencies openapi og swagger siden dette inkluderes via kompendium i stedet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,9 +39,7 @@ dependencies {
     // Ktor
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)
-    implementation(libs.ktor.server.swagger)
     implementation(libs.ktor.server.cors)
-    implementation(libs.ktor.server.openapi)
 
     // Monitoring
     implementation(libs.ktor.server.call.logging)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,9 +19,7 @@ testcontainersVersion = "1.20.1"
 [libraries]
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core-jvm", version.ref = "ktorVersion" }
 ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty-jvm", version.ref = "ktorVersion" }
-ktor-server-swagger = { group = "io.ktor", name = "ktor-server-swagger", version.ref = "ktorVersion" }
 ktor-server-cors = { group = "io.ktor", name = "ktor-server-cors", version.ref = "ktorVersion" }
-ktor-server-openapi = { group = "io.ktor", name = "ktor-server-openapi", version.ref = "ktorVersion" }
 ktor-server-tests = { group = "io.ktor", name = "ktor-server-tests-jvm", version.ref = "ktorVersion" }
 ktor-server-call-logging = { group = "io.ktor", name = "ktor-server-call-logging", version.ref = "ktorVersion" }
 ktor-server-metrics-micrometer = { group = "io.ktor", name = "ktor-server-metrics-micrometer", version.ref = "ktorVersion" }


### PR DESCRIPTION
Kompendium ser ut til å inkludere det nødvendige for å få generert og vist swagger UIet så kan derfor inntil videre fjerne både ktor-openapi og ktor-swagger som for meg ser ubrukt ut. Dette gjør også at vi får fjernet en sårbarhet.