### PR TITLE
Switch github workflow master

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -72,7 +72,7 @@ jobs:
   deploy:
     needs: [ build ]
     name: Deploy to dev
-    uses: kartverket/bygning-apps/.github/workflows/update-app-version.yaml@main
+    uses: kartverket/bygning-github-workflows/.github/workflows/update-app-version.yaml@main
     permissions:
       id-token: write
     with:


### PR DESCRIPTION
Litt usikker på om man må endre noe i forbindelse med octo-sts greiene. Det er jo fortsatt dette repoet som trenger token, så er bare frågan om man må legge til noe ekstra fra `bygning-github-workflows`. Tenker bare få inn denne og se om det funker