### PR TITLE
Remove bygningclient from egenreg service

### DIFF
--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -96,8 +96,7 @@ fun Application.mainModule() {
         config.property("ktor.development").getString().toBoolean(),
     )
 
-    // Kanskje litt snålt at EgenregService får bygningClient, men vi sender den også med til BaseRouting
-    val egenregistreringsService = EgenregistreringsService(bygningClient)
+    val egenregistreringsService = EgenregistreringsService()
 
     installBaseRouting(
         bygningClient = bygningClient,

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/EgenregisteringRoutes.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/EgenregisteringRoutes.kt
@@ -40,7 +40,7 @@ fun Route.egenregistreringRouting(
             }
 
             val addedEgenregistrering =
-                egenregistreringsService.addEgenregistreringToBygning(bygningId.toLong(), egenregistrering)
+                egenregistreringsService.addEgenregistreringToBygning(bygningFromMatrikkel, egenregistrering)
 
             if (addedEgenregistrering) {
                 call.respondText(

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/services/EgenregistreringsService.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/services/EgenregistreringsService.kt
@@ -1,21 +1,19 @@
 package no.kartverket.matrikkel.bygning.services
 
-import no.kartverket.matrikkel.bygning.matrikkel.BygningClient
+import no.kartverket.matrikkel.bygning.models.Bygning
 import no.kartverket.matrikkel.bygning.models.requests.BruksenhetRegistrering
 import no.kartverket.matrikkel.bygning.models.requests.BygningsRegistrering
 import no.kartverket.matrikkel.bygning.models.requests.EgenregistreringRequest
 import java.util.*
 
-class EgenregistreringsService(private val bygningClient: BygningClient) {
+class EgenregistreringsService {
     private val bygningRegistreringer: MutableList<BygningsRegistrering> = mutableListOf()
     private val bruksenhetRegistreringer: MutableList<BruksenhetRegistrering> = mutableListOf()
 
-    fun addEgenregistreringToBygning(bygningId: Long, egenregistrering: EgenregistreringRequest): Boolean {
-        val bygningIfExists = bygningClient.getBygningById(bygningId) ?: return false
-
+    fun addEgenregistreringToBygning(bygning: Bygning, egenregistrering: EgenregistreringRequest): Boolean {
         val isAllBruksenheterRegisteredOnCorrectBygning =
             egenregistrering.bruksenhetRegistreringer.any { bruksenhetRegistering ->
-                bygningIfExists.bruksenheter.find { it.bruksenhetId == bruksenhetRegistering.bruksenhetId } != null
+                bygning.bruksenheter.find { it.bruksenhetId == bruksenhetRegistering.bruksenhetId } != null
             }
 
         if (!isAllBruksenheterRegisteredOnCorrectBygning) return false


### PR DESCRIPTION
Unngår den litt snåle instansieringen samt henter ikke bygning fra matrikkel to ganger

Kan hende det gir mer mening å sende bygningClient videre til EgenregService i stedet for å gjøre det ute i routen, litt usikker på fordeler/ulemper rundt det.