### PR TITLE
TH-51 Justeringer av oppsett lokalt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(libs.flyway.database.postgresql)
     implementation(libs.hikari)
 
+    // OpenAPI
     implementation(libs.kompendium.core)
 
     // Integration tests

--- a/src/intTest/kotlin/no/kartverket/matrikkel/bygning/TestWithDb.kt
+++ b/src/intTest/kotlin/no/kartverket/matrikkel/bygning/TestWithDb.kt
@@ -54,7 +54,10 @@ abstract class TestWithDb {
                 config = MapApplicationConfig(
                     "storage.jdbcURL" to postgresSQLContainer.jdbcUrl.removePrefix("jdbc:"),
                     "storage.username" to postgresSQLContainer.username,
-                    "storage.password" to postgresSQLContainer.password
+                    "storage.password" to postgresSQLContainer.password,
+                    "matrikkel.baseUrl" to "",
+                    "matrikkel.username" to "",
+                    "matrikkel.password" to "",
                 )
             }
         }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/config/Env.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/config/Env.kt
@@ -1,0 +1,16 @@
+package no.kartverket.matrikkel.bygning.config
+
+enum class Env {
+    LOCAL,
+    SKIP;
+
+    companion object {
+        // Checks if the app is running on k8s/SKIP
+        fun current(): Env = when (System.getenv("KUBERNETES_SERVICE_HOST") != null) {
+            true -> SKIP
+            false -> LOCAL
+        }
+
+        fun isLocal() = current() == LOCAL
+    }
+}

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/config/LoadConfiguration.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/config/LoadConfiguration.kt
@@ -1,0 +1,28 @@
+package no.kartverket.matrikkel.bygning.config
+
+import io.ktor.server.application.*
+import io.ktor.server.config.*
+import no.kartverket.matrikkel.bygning.config.Env.LOCAL
+import no.kartverket.matrikkel.bygning.config.Env.SKIP
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val log: Logger = LoggerFactory.getLogger(object {}::class.java)
+
+fun loadConfiguration(environment: ApplicationEnvironment): ApplicationConfig =
+    // Any properties set in tests or similar will be used first, then fall back to config from application.conf
+    configLocation()
+        .let {
+            log.info("Loading configuration using file: {}", it)
+            environment.config.withFallback(ApplicationConfig(it))
+        }
+
+
+private fun configLocation(): String {
+    return when (Env.current()) {
+        SKIP -> "application.conf"
+        LOCAL -> "application-local.conf"
+    }
+}
+
+

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/MatrikkelApiConfig.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/MatrikkelApiConfig.kt
@@ -1,28 +1,24 @@
 package no.kartverket.matrikkel.bygning.matrikkel
 
+import no.kartverket.matrikkel.bygning.config.Env
 import no.kartverket.matrikkel.bygning.matrikkel.adapters.LocalBygningClient
 import no.kartverket.matrikkel.bygning.matrikkel.adapters.MatrikkelBygningClient
 import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelApi
 import java.net.URI
 
-
 fun createBygningClient(
     matrikkelBaseUrl: String,
     matrikkelUsername: String,
     matrikkelPassword: String,
-    isDevelopment: Boolean,
 ): BygningClient {
-    if (isDevelopment) {
-        return LocalBygningClient()
+    return when {
+        Env.isLocal() -> {
+            LocalBygningClient()
+        }
+        else -> MatrikkelBygningClient(
+            MatrikkelApi(
+                URI(matrikkelBaseUrl),
+            ).withAuth(matrikkelUsername, matrikkelPassword)
+        )
     }
-
-    if (matrikkelUsername.isEmpty() || matrikkelPassword.isEmpty() || matrikkelBaseUrl.isEmpty()) {
-        throw RuntimeException("MatrikkelConfig mangler brukernavn, passord eller base url. Dersom applikasjonen kjører i sky er disse miljøvariablene påkrevd")
-    }
-
-    return MatrikkelBygningClient(
-        MatrikkelApi(
-            URI(matrikkelBaseUrl),
-        ).withAuth(matrikkelUsername, matrikkelPassword)
-    )
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClient.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClient.kt
@@ -1,6 +1,5 @@
 package no.kartverket.matrikkel.bygning.matrikkel.adapters
 
-import io.ktor.util.logging.*
 import no.kartverket.matrikkel.bygning.matrikkel.BygningClient
 import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelApi
 import no.kartverket.matrikkel.bygning.matrikkelapi.getObjectAs
@@ -9,6 +8,8 @@ import no.kartverket.matrikkel.bygning.models.Bruksenhet
 import no.kartverket.matrikkel.bygning.models.Bygning
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.service.store.ServiceException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bruksenhet as MatrikkelBruksenhet
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bygning as MatrikkelBygning
 
@@ -17,7 +18,7 @@ import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bygning as Mat
 internal class MatrikkelBygningClient(
     val matrikkelApi: MatrikkelApi.WithAuth
 ) : BygningClient {
-    private val LOGGER = KtorSimpleLogger("MatrikkelBygningClient")
+    private val LOG: Logger = LoggerFactory.getLogger(MatrikkelBygningClient::class.java)
 
     override fun getBygningById(id: Long): Bygning? {
         val bygningId: BygningId = BygningId().apply { value = id }
@@ -37,7 +38,7 @@ internal class MatrikkelBygningClient(
                     )
                 })
         } catch (exception: ServiceException) {
-            LOGGER.warn("Noe gikk galt under henting av bygning med id $bygningId: ${exception.message}")
+            LOG.warn("Noe gikk galt under henting av bygning med id {}", bygningId, exception)
             return null
         }
     }
@@ -48,7 +49,7 @@ internal class MatrikkelBygningClient(
 
             return getBygningById(bygningId.value)
         } catch (exception: ServiceException) {
-            LOGGER.warn("Noe gikk galt under henting av bygning med nummer $bygningNummer: ${exception.message}")
+            LOG.warn("Noe gikk galt under henting av bygning med nummer {}", bygningNummer, exception)
             return null
         }
     }

--- a/src/main/resources/application-local.conf
+++ b/src/main/resources/application-local.conf
@@ -1,0 +1,18 @@
+storage {
+    jdbcURL = "postgresql://localhost:5432/postgres"
+    username = "postgres"
+    password = "postgres"
+}
+
+matrikkel {
+    username = ${?MATRIKKEL_USERNAME}
+    password = ${?MATRIKKEL_PASSWORD}
+    baseUrl = "https://betatest.matrikkel.no"
+}
+
+// Dette er én løsning for å fikse lokal vs. ikke lokal config
+// Fordelen med å bruke ktor.development flagget er at det også kan brukes til å fikse hot-reloading hvis man ønsker dette
+// Ikke sett på å sette det opp selv
+ktor  {
+    development = true
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,24 +1,11 @@
-# Dette formatet gjør at man kan skrive over default verdier med miljøvariabler. Jeg synes ikke det er kjempepent, men det gjør at vi ikke trenger å merge disse på noe vis i en egen fil
 storage {
-    jdbcURL = "postgresql://localhost:5432/postgres"
-    jdbcURL = ${?DB_URL}
-    username = "postgres"
-    username = ${?DB_USERNAME}
-    password = "postgres"
-    password = ${?DB_PASSWORD}
+    jdbcURL = ${DB_URL}
+    username = ${DB_USERNAME}
+    password = ${DB_PASSWORD}
 }
 
 matrikkel {
-    username = ${?MATRIKKEL_USERNAME}
-    password = ${?MATRIKKEL_PASSWORD}
-    baseUrl = "https://betatest.matrikkel.no"
-    baseUrl = ${?MATRIKKEL_BASE_URL}
-}
-
-// Dette er én løsning for å fikse lokal vs. ikke lokal config
-// Fordelen med å bruke ktor.development flagget er at det også kan brukes til å fikse hot-reloading hvis man ønsker dette
-// Ikke sett på å sette det opp selv
-ktor  {
-    development = true
-    development = ${?DEVELOPMENT}
+    username = ${MATRIKKEL_USERNAME}
+    password = ${MATRIKKEL_PASSWORD}
+    baseUrl = ${MATRIKKEL_BASE_URL}
 }


### PR DESCRIPTION
* Etabler et env-konsept for å skille mellom config når man kjører lokalt og på SKIP. Litt usikker på det beste her, og om det f.eks. finnes andre variabler man kan bruke for å skille hvor man kjører.
* Skill ut config i to separate filer for å unngå å ha default-verdier og lokale verdier i prod-config.
* Hovedtanken er nå at i "prod" modus så vil app-en feile hvis nødvendige config-verdier ikke er satt i stedet for å bruke default-verdier

Vi bør jo fortsatt ha mulighet til å gå direkte mot matrikkel APIet når vi kjører lokalt tenker jeg, så ikke sikkert det blir helt riktig å ha `Env.isLocal()` som betingelse for hvor vi kjører, men det får vi bare justere når vi jobber med dette fremover.