### PR TITLE
Legg opp til enklere portkonflikthåndtering i docker og applikasjon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 
 ### Jenv ###
 .java-version
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:21-jdk-alpine
-EXPOSE 8080:8080
+EXPOSE ${PORT:-8080}:${PORT:-8080}
 RUN mkdir /app
 COPY /build/libs/matrikkel-bygning-egenregistrering-all.jar /app/app.jar
 ENTRYPOINT ["java", "-Dlogback.configurationFile=logback-cloud.xml", "-jar","/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ fyll ut README med informasjon om dette.
 
 Prosjektet er bygd og kjørt med `temurin-21` JRE og IntelliJ default Kotlin SDK.
 
+
+### TLDR
+Vil du kjøre alt av applikasjon og database med Docker, gjør følgende:
+```shell
+$ export PORT=<PORT_NUMMER>          # Optional
+$ export INTERNAL_PORT=<PORT_NUMMER> # Optional
+$ ./gradlew build
+$ docker-compose up
+```
+
 ### Kjøring av database
 
 For å kjøre applikasjonen må du først starte en database. For lokal kjøring er det definert en postgres-database i

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ INTERNAL_PORT=<PORT_NUMMER>
 `PORT` brukes for selve applikasjonen, mens `INTERNAL_PORT` brukes for interne endepunkter som metrikker og
 helsesjekker.
 
+**NB**: `.env` for å sette disse variablene fungerer kun dersom du bruker Docker for å kjøre applikasjonen. Dersom du
+ønsker å kjøre via IntelliJ eller liknende må du sette disse i runtime configurationen din.
+
 ### Integrasjon mot matrikkel APIet
 
 Som standard brukes det en stub/mock mot matrikkel APIet når applikasjonen kjører lokalt.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,44 @@ Databasen kan startes med docker compose:
 $ docker-compose up db -d
 ```
 
-Flagget `-d` gjør at loggene fra containeren ikke skrives til stdout. Dersom du ønsker det kan du droppe flagget.
+Flagget `-d` gjør at containeren kjøres i detached modus og loggene fra containeren ikke skrives til stdout. Dersom du
+ønsker det kan du droppe flagget.
+
+### Kjøring av applikasjon
+
+Når databasen kjører, kan du kjøre opp applikasjonen enten lokalt, eller som en Docker container. Før du gjør dette må
+du bygge applikasjonen, dette kan gjøres med gradle:
+
+```sh
+$ ./gradlew build
+```
+
+Hvis du vil kjøre appen som en Docker container kan du kjøre:
+
+```sh
+$ docker-compose up web -d
+```
+
+Ellers er det bare å kjøre opp applikasjonen som ønsket via IntelliJ eller kommandolinje. Ingen spesielle hensyn som er
+nødvendig rundt miljøkonfigurasjon, det skal ha sane defaults.
+
+#### Håndtering av portkonflikter
+
+Applikasjonen er satt opp til å håndtere bruk av andre porter enn default 8080 og 8081. Hvis du ønsker å bruke dette kan
+du opprette en fil ved navn `.env` på rot i prosjektet. Denne filen blir ignorert av git og sjekkes ikke inn. Sett så
+følgende variabler:
+
+```
+PORT=<PORT_NUMMER>
+INTERNAL_PORT=<PORT_NUMMER>
+```
+
+`PORT` brukes for selve applikasjonen, mens `INTERNAL_PORT` brukes for interne endepunkter som metrikker og
+helsesjekker.
 
 ### Integrasjon mot matrikkel APIet
 
-Som standard brukes det en stub/mock mot matrikkel APIet når applikasjonen kjører lokalt. 
+Som standard brukes det en stub/mock mot matrikkel APIet når applikasjonen kjører lokalt.
 For å endre til å gå mot et faktisk kjørende matrikkel, må propertien `matrikkel.useStub` settes til `false`
 i [application-local.conf](./src/main/resources/application-local.conf)
 
@@ -39,22 +72,10 @@ MATRIKKEL_USERNAME
 MATRIKKEL_PASSWORD
 ```
 
-### Kjøring av applikasjon
-
-Når databasen kjører, kan du kjøre opp applikasjonen enten lokalt, eller som en Docker container.
-
-Hvis du vil kjøre appen som en Docker container kan du kjøre:
-
-```sh
-$ docker-compose up web -d
-```
-
-Ellers er det bare å kjøre opp applikasjonen som ønsket via IntelliJ eller kommandolinje. Ingen spesielle hensyn som er
-nødvendig rundt miljøkonfigurasjon, det skal ha sane defaults.
-
 ### Integrasjonstester
 
-Prosjektet inneholder noen integrasjonstester som ligger under [src/integrationTest](src/integrationTest). Testene bruker blant annet
+Prosjektet inneholder noen integrasjonstester som ligger under [src/integrationTest](src/integrationTest). Testene
+bruker blant annet
 testcontainers for å kjøre opp en database som bruke under testene.
 
 Testene er definert med en egen task som kan kjøres slik:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,11 @@ services:
   web:
     build: .
     ports:
-      - "8080:8080"
+      - "${PORT:-8080}:${PORT:-8080}"
     environment:
       DB_URL: postgresql://db:5432/postgres
+      PORT: "${PORT:-8080}"
+      INTERNAL_PORT: "${INTERNAL_PORT:-8081}"
     depends_on:
       db:
         condition: service_healthy

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -23,15 +23,18 @@ import no.kartverket.matrikkel.bygning.services.EgenregistreringsService
 import no.kartverket.matrikkel.bygning.services.HealthService
 
 fun main() {
+    val internalPort = System.getenv("INTERNAL_PORT")?.toIntOrNull() ?: 8081
+    val port = System.getenv("PORT")?.toIntOrNull() ?: 8080
+
     embeddedServer(
         factory = Netty,
-        port = 8081,
+        port = internalPort,
         module = Application::internalModule,
     ).start(wait = false)
 
     embeddedServer(
         factory = Netty,
-        port = 8080,
+        port = port,
         module = Application::mainModule,
         watchPaths = listOf("classes"),
     ).start(wait = true)

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
@@ -1,7 +1,6 @@
 package no.kartverket.matrikkel.bygning.plugins
 
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
-import io.bkbn.kompendium.json.schema.KotlinXSchemaConfigurator
 import io.bkbn.kompendium.oas.OpenApiSpec
 import io.bkbn.kompendium.oas.info.Info
 import io.ktor.server.application.*
@@ -15,6 +14,5 @@ fun Application.configureOpenAPI() {
                 version = "0.1",
             ),
         )
-        schemaConfigurator = KotlinXSchemaConfigurator()
     }
 }

--- a/src/main/resources/application-local.conf
+++ b/src/main/resources/application-local.conf
@@ -1,5 +1,6 @@
 storage {
   jdbcURL = "postgresql://localhost:5432/postgres"
+  jdbcURL = ${?DB_URL}
   username = "postgres"
   password = "postgres"
 }


### PR DESCRIPTION
CC @christianmosveen 

Tillater nå at `PORT` og `INTERNAL_PORT` kan leses automatisk fra en `.env` fil.

Valgte å ikke sette dette i application config da man ikke har `loadConfiguration` tilgjengelig ved oppstart av server.

Kan jo være det er verdt å se på å legge inn støtte for `.env` generelt når man først støtter det på et vis her, men det kan komme senere, methinks

Flytta også litt på README så det var lettere å se hvor lite som skulle til for å faktisk sette opp alt