### PR TITLE
Erstatt kotlinx.time med java.time

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,6 @@ dependencies {
     // Serialization
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx)
-    implementation(libs.kotlinx.datetime)
 
     // Persistence
     implementation(libs.postgres)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ jacksonVersion = "2.17.2"
 postgresVersion = "42.7.3"
 shadowVersion = "8.1.1"
 kompendiumVersion = "3.14.4"
-kotlinxDatetimeVersion = "0.6.0"
 jaxwsVersion = "4.0.3"
 hikariVersion = "5.1.0"
 assertjVersion = "3.26.3"
@@ -40,7 +39,6 @@ jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-datab
 postgres = { group = "org.postgresql", name = "postgresql", version.ref = "postgresVersion" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit5", version.ref = "kotlinVersion" }
 kompendium-core = { group = "io.bkbn", name = "kompendium-core", version.ref = "kompendiumVersion" }
-kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetimeVersion" }
 
 jaxws-rt = { group = "com.sun.xml.ws", name = "jaxws-rt", version.ref = "jaxwsVersion" }
 jaxws-tools = { group = "com.sun.xml.ws", name = "jaxws-tools", version.ref = "jaxwsVersion" }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
@@ -1,9 +1,13 @@
 package no.kartverket.matrikkel.bygning.plugins
 
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
+import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.OpenApiSpec
 import io.bkbn.kompendium.oas.info.Info
 import io.ktor.server.application.*
+import java.time.Instant
+import java.time.LocalDate
+import kotlin.reflect.typeOf
 
 fun Application.configureOpenAPI() {
     install(NotarizedApplication()) {
@@ -13,6 +17,10 @@ fun Application.configureOpenAPI() {
                 title = "API For Egenregistrering av Bygningsdata",
                 version = "0.1",
             ),
+        )
+        customTypes = mapOf(
+            typeOf<LocalDate>() to TypeDefinition(type = "string", format = "date"),
+            typeOf<Instant>() to TypeDefinition(type = "string", format = "date-time"),
         )
     }
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/serializers/InstantSerializer.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/serializers/InstantSerializer.kt
@@ -1,0 +1,21 @@
+package no.kartverket.matrikkel.bygning.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.Instant
+
+object InstantSerializer : KSerializer<Instant> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Instant", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Instant {
+        return Instant.parse(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeString(value.toString())
+    }
+}

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/serializers/LocalDateSerializer.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/serializers/LocalDateSerializer.kt
@@ -1,0 +1,20 @@
+package no.kartverket.matrikkel.bygning.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.LocalDate
+
+object LocalDateSerializer : KSerializer<LocalDate> {
+    override val descriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): LocalDate {
+        return LocalDate.parse(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: LocalDate) {
+        encoder.encodeString(value.toString())
+    }
+}


### PR DESCRIPTION
Test på å se hva som skal til for å erstatte kotlinx.time med java.time

Ser primært ut som at to ting må gjøres:

* Skrive egne serialiserer for Instant og LocalDate og legge disse på de aktuelle feltene (man får en kompileringsfeil hvis man angir java.time.LocalDate uten å ha korrekt serialiserer)
* Konfigurere kompendium slik at den forstår hvordan java.time typene skal håndteres i OpenAPI spesifikasjonen. Benytter da typene som finnes i henhold til OpenAPI spec-en (date og date-time): https://swagger.io/docs/specification/data-models/data-types/

Ta gjerne en titt så kan vi ta en vurdering på hva vi ønsker å gå videre med.