### PR TITLE
Sett feltnavn for registreringer til å inneholde registrering

### DIFF
--- a/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/EgenregistreringRouteTest.kt
+++ b/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/EgenregistreringRouteTest.kt
@@ -23,17 +23,17 @@ class EgenregistreringRouteTest : TestWithDb() {
             setBody(
                 EgenregistreringRequest(
                     bygningRegistrering = BygningRegistrering(
-                        bruksareal = BruksarealRegistrering(bruksareal = 125.0),
-                        byggeaar = ByggeaarRegistrering(byggeaar = 2010),
-                        vannforsyning = null,
-                        avlop = null,
+                        bruksarealRegistrering = BruksarealRegistrering(bruksareal = 125.0),
+                        byggeaarRegistrering = ByggeaarRegistrering(byggeaar = 2010),
+                        vannforsyningRegistrering = null,
+                        avlopRegistrering = null,
                     ),
                     bruksenhetRegistreringer = listOf(
                         BruksenhetRegistrering(
                             bruksenhetId = 1L,
-                            bruksareal = BruksarealRegistrering(bruksareal = 50.0),
-                            energikilde = null,
-                            oppvarming = null,
+                            bruksarealRegistrering = BruksarealRegistrering(bruksareal = 50.0),
+                            energikildeRegistrering = null,
+                            oppvarmingRegistrering = null,
                         ),
                     ),
                 ),
@@ -52,17 +52,17 @@ class EgenregistreringRouteTest : TestWithDb() {
             setBody(
                 EgenregistreringRequest(
                     bygningRegistrering = BygningRegistrering(
-                        bruksareal = BruksarealRegistrering(bruksareal = 125.0),
-                        byggeaar = ByggeaarRegistrering(byggeaar = 2010),
-                        vannforsyning = null,
-                        avlop = null,
+                        bruksarealRegistrering = BruksarealRegistrering(bruksareal = 125.0),
+                        byggeaarRegistrering = ByggeaarRegistrering(byggeaar = 2010),
+                        vannforsyningRegistrering = null,
+                        avlopRegistrering = null,
                     ),
                     bruksenhetRegistreringer = listOf(
                         BruksenhetRegistrering(
                             bruksenhetId = 3L,
-                            bruksareal = BruksarealRegistrering(bruksareal = 50.0),
-                            energikilde = null,
-                            oppvarming = null,
+                            bruksarealRegistrering = BruksarealRegistrering(bruksareal = 50.0),
+                            energikildeRegistrering = null,
+                            oppvarmingRegistrering = null,
                         ),
                     ),
                 ),

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/requests/EgenregistreringRequest.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/requests/EgenregistreringRequest.kt
@@ -38,18 +38,18 @@ data class OppvarmingRegistrering(
 
 @Serializable
 data class BygningRegistrering(
-    val bruksareal: BruksarealRegistrering?,
-    val byggeaar: ByggeaarRegistrering?,
-    val vannforsyning: VannforsyningRegistrering?,
-    val avlop: AvlopRegistrering?
+    val bruksarealRegistrering: BruksarealRegistrering?,
+    val byggeaarRegistrering: ByggeaarRegistrering?,
+    val vannforsyningRegistrering: VannforsyningRegistrering?,
+    val avlopRegistrering: AvlopRegistrering?
 )
 
 @Serializable
 data class BruksenhetRegistrering(
     val bruksenhetId: Long,
-    val bruksareal: BruksarealRegistrering?,
-    val energikilde: EnergikildeRegistrering?,
-    val oppvarming: OppvarmingRegistrering?
+    val bruksarealRegistrering: BruksarealRegistrering?,
+    val energikildeRegistrering: EnergikildeRegistrering?,
+    val oppvarmingRegistrering: OppvarmingRegistrering?
 )
 
 @Serializable

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/BygningRoutes.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/BygningRoutes.kt
@@ -9,8 +9,8 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import no.kartverket.matrikkel.bygning.matrikkel.BygningClient
 import no.kartverket.matrikkel.bygning.matrikkel.Bygning
+import no.kartverket.matrikkel.bygning.matrikkel.BygningClient
 
 fun Route.bygningRouting(
     bygningClient: BygningClient,

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/EgenregisteringRoutes.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/EgenregisteringRoutes.kt
@@ -65,7 +65,7 @@ private fun Route.egenregistreringBygningIdDoc() {
                 examples(
                     "Bygning Id 1" to EgenregistreringRequest(
                         bygningRegistrering = BygningRegistrering(
-                            bruksareal = BruksarealRegistrering(
+                            bruksarealRegistrering = BruksarealRegistrering(
                                 bruksareal = 125.0,
                             ),
                             null,
@@ -76,7 +76,7 @@ private fun Route.egenregistreringBygningIdDoc() {
                             BruksenhetRegistrering(
                                 bruksenhetId = 1L,
                                 null,
-                                energikilde = EnergikildeRegistrering(
+                                energikildeRegistrering = EnergikildeRegistrering(
                                     energikilder = listOf(EnergikildeKode.Elektrisitet, EnergikildeKode.Gass),
                                 ),
                                 null,

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/services/EgenregistreringService.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/services/EgenregistreringService.kt
@@ -47,10 +47,10 @@ class EgenregistreringService(private val bygningClient: BygningClient) {
     private fun addEgenregistreringToBygning(egenregistrering: EgenregistreringRequest) {
         bygningRegistreringer.add(
             BygningRegistrering(
-                bruksareal = egenregistrering.bygningRegistrering.bruksareal,
-                byggeaar = egenregistrering.bygningRegistrering.byggeaar,
-                vannforsyning = egenregistrering.bygningRegistrering.vannforsyning,
-                avlop = egenregistrering.bygningRegistrering.avlop,
+                bruksarealRegistrering = egenregistrering.bygningRegistrering.bruksarealRegistrering,
+                byggeaarRegistrering = egenregistrering.bygningRegistrering.byggeaarRegistrering,
+                vannforsyningRegistrering = egenregistrering.bygningRegistrering.vannforsyningRegistrering,
+                avlopRegistrering = egenregistrering.bygningRegistrering.avlopRegistrering,
             ),
         )
     }
@@ -60,9 +60,9 @@ class EgenregistreringService(private val bygningClient: BygningClient) {
             bruksenhetRegistreringer.add(
                 BruksenhetRegistrering(
                     bruksenhetId = bruksenhetRegistrering.bruksenhetId,
-                    bruksareal = bruksenhetRegistrering.bruksareal,
-                    energikilde = bruksenhetRegistrering.energikilde,
-                    oppvarming = bruksenhetRegistrering.oppvarming,
+                    bruksarealRegistrering = bruksenhetRegistrering.bruksarealRegistrering,
+                    energikildeRegistrering = bruksenhetRegistrering.energikildeRegistrering,
+                    oppvarmingRegistrering = bruksenhetRegistrering.oppvarmingRegistrering,
                 ),
             )
         }


### PR DESCRIPTION
Var litt snålt å ha f. eks ha `bruksareal.bruksareal = 125.0` fremfor å tydeliggjøre at man har en bruksareal<i>registrering</i> som har bruksareal