### PR TITLE
Tb 52 Legg til action dependency review

### DIFF
--- a/.github/actions/setup-java/action.yaml
+++ b/.github/actions/setup-java/action.yaml
@@ -1,0 +1,12 @@
+name: Setup java
+description: Setup Java with correct version
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -24,10 +24,7 @@ jobs:
       - name: Checkout project sources
         uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
+        uses: ./.github/actions/setup-java
       - name: Run build and integration tests
         run: ./gradlew build integrationTest
       - name: Build and push docker

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -23,12 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review-pr.yaml
+++ b/.github/workflows/dependency-review-pr.yaml
@@ -1,0 +1,24 @@
+name: Dependency Review for PR
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
+      - name: Dependency submission
+        uses: gradle/actions/dependency-submission@v4
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: true
+          allow-licenses: MIT, Apache-2.0

--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -1,0 +1,18 @@
+name: Dependency Submission
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
* Legger til 2 workflows: En som submitter alle dependencies til submission APIet på main-branchen og en som sjekker etter nye dependencies med sårbarheter eller uønskede lisenser på PR-er
* Sjekker også etter sårbarheter i tillegg til lisenser i 3. parts libs
* Tillater følgende lisenser: MIT og Apache 2