### PR TITLE
TB-59 Aggregerte registeringer på bruksenhet og bygning

### DIFF
--- a/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepositoryTest.kt
+++ b/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepositoryTest.kt
@@ -4,6 +4,7 @@ import no.kartverket.matrikkel.bygning.models.BruksarealRegistrering
 import no.kartverket.matrikkel.bygning.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.models.Egenregistrering
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.*
@@ -67,5 +68,15 @@ class EgenregistreringRepositoryTest : TestWithDb() {
         val registreringer = egenregistreringRepository.getAllEgenregistreringerForBygning(2L)
 
         assertThat(registreringer).isEmpty()
+    }
+
+    // Aner ikke om dette er en vettug måte å gjøre dette på? Vi må ha en måte å ha en tom db mellom tester, hvert fall
+    @BeforeEach
+    fun clearEgenregistreringer() {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute("DELETE FROM bygning.egenregistrering")
+            }
+        }
     }
 }

--- a/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepositoryTest.kt
+++ b/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepositoryTest.kt
@@ -1,7 +1,6 @@
 package no.kartverket.matrikkel.bygning.repositories
 
 import no.kartverket.matrikkel.bygning.models.BruksarealRegistrering
-import no.kartverket.matrikkel.bygning.models.BruksenhetRegistrering
 import no.kartverket.matrikkel.bygning.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.models.Egenregistrering
 import org.assertj.core.api.Assertions.assertThat
@@ -13,8 +12,6 @@ class EgenregistreringRepositoryTest : TestWithDb() {
     val egenregistreringRepository = EgenregistreringRepository(dataSource)
 
     val defaultBygningRegistrering = BygningRegistrering(
-        registreringId = UUID.randomUUID(),
-        registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
         bygningId = 1L,
         bruksarealRegistrering = BruksarealRegistrering(
             bruksareal = 125.0,
@@ -22,82 +19,53 @@ class EgenregistreringRepositoryTest : TestWithDb() {
         byggeaarRegistrering = null,
         vannforsyningRegistrering = null,
         avlopRegistrering = null,
-    )
-
-    val defaultBruksenhetRegistrering = BruksenhetRegistrering(
-        registreringId = UUID.randomUUID(),
-        registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
-        bruksenhetId = 1L,
-        bruksarealRegistrering = BruksarealRegistrering(
-            bruksareal = 125.0,
-        ),
-        energikildeRegistrering = null,
-        oppvarmingRegistrering = null,
+        bruksenhetRegistreringer = emptyList()
     )
 
     val defaultEgenregistrering = Egenregistrering(
         id = UUID.randomUUID(),
         registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
-        bygningId = 1L,
         bygningRegistrering = defaultBygningRegistrering,
-        bruksenhetRegistreringer = emptyList(),
-    )
-
-    val defaultBruksenhetEgenregistrering = defaultEgenregistrering.copy(
-        bygningRegistrering = null,
-        bruksenhetRegistreringer = listOf(
-            defaultBruksenhetRegistrering,
-        ),
     )
 
     @Test
-    fun `lagring av to egenregistreringer med bygningregistrering skal returnere nyeste registrering ved henting`() {
-        val newUUIDEgenregistrering = UUID.randomUUID()
-        val newUUIDBygningRegistrering = UUID.randomUUID()
+    fun `lagring av 1 egenregistrering skal kun returnere 1 egenregistrering`() {
+        egenregistreringRepository.saveEgenregistrering(defaultEgenregistrering)
 
-        val registrering2 = defaultEgenregistrering.copy(
-            id = newUUIDEgenregistrering,
-            defaultEgenregistrering.registreringstidspunkt.plusSeconds(60),
-            bygningRegistrering = defaultBygningRegistrering.copy(
-                registreringId = newUUIDBygningRegistrering,
-                bruksarealRegistrering = BruksarealRegistrering(
-                    bruksareal = 130.0,
-                ),
-            ),
+        val bygningRegistreringer = egenregistreringRepository.getAllEgenregistreringerForBygning(1L)
+
+        assertThat(bygningRegistreringer).size().isEqualTo(1)
+        assertThat(bygningRegistreringer[0]).satisfies(
+            { egenregistrering ->
+                assertThat(egenregistrering.id).isEqualTo(defaultEgenregistrering.id)
+                assertThat(egenregistrering.registreringstidspunkt).isEqualTo(defaultEgenregistrering.registreringstidspunkt)
+            }
+        )
+    }
+
+    @Test
+    fun `lagring av 2 egenregistreringer skal returneres i riktig rekkefolge med seneste registreringer forst i listen`() {
+        val laterRegistreringId = UUID.randomUUID()
+        val laterRegistrering = defaultEgenregistrering.copy(
+            id = laterRegistreringId,
+            registreringstidspunkt = defaultEgenregistrering.registreringstidspunkt.plusSeconds(60)
         )
 
         egenregistreringRepository.saveEgenregistrering(defaultEgenregistrering)
-        egenregistreringRepository.saveEgenregistrering(registrering2)
+        egenregistreringRepository.saveEgenregistrering(laterRegistrering)
 
-        val newestBygningRegistrering = egenregistreringRepository.findNewestBygningRegistrering(1L)
+        val registreringer = egenregistreringRepository.getAllEgenregistreringerForBygning(1L)
 
-        assertThat(newestBygningRegistrering?.bruksarealRegistrering?.bruksareal).isEqualTo(130.0)
+        assertThat(registreringer[0].id).isEqualTo(laterRegistrering.id)
+        assertThat(registreringer[1].id).isEqualTo(defaultEgenregistrering.id)
     }
 
-
     @Test
-    fun `lagring av to egenregistreringer med bruksenhetregistrering skal returnere nyeste registrering ved henting`() {
-        val newUUIDEgenregistrering = UUID.randomUUID()
-        val newUUIDBruksenhetRegistrering = UUID.randomUUID()
+    fun `henting av registreringer skal gi tom liste hvis bygningen ikke har registreringer`() {
+        egenregistreringRepository.saveEgenregistrering(defaultEgenregistrering)
 
-        val registrering2 = defaultBruksenhetEgenregistrering.copy(
-            id = newUUIDEgenregistrering,
-            defaultEgenregistrering.registreringstidspunkt.plusSeconds(60),
-            bruksenhetRegistreringer = listOf(
-                defaultBruksenhetRegistrering.copy(
-                    registreringId = newUUIDBruksenhetRegistrering,
-                    bruksarealRegistrering = BruksarealRegistrering(
-                        bruksareal = 130.0,
-                    ),
-                ),
-            ),
-        )
+        val registreringer = egenregistreringRepository.getAllEgenregistreringerForBygning(2L)
 
-        egenregistreringRepository.saveEgenregistrering(defaultBruksenhetEgenregistrering)
-        egenregistreringRepository.saveEgenregistrering(registrering2)
-
-        val newestBruksenhetRegistrering = egenregistreringRepository.findNewestBruksenhetRegistrering(1L)
-
-        assertThat(newestBruksenhetRegistrering?.bruksarealRegistrering?.bruksareal).isEqualTo(130.0)
+        assertThat(registreringer).isEmpty()
     }
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -61,7 +61,7 @@ fun Application.mainModule() {
 
 
     val egenregistreringService = EgenregistreringService(bygningClient, egenregistreringRepository)
-    val bygningService = BygningService(bygningClient, egenregistreringRepository)
+    val bygningService = BygningService(bygningClient, egenregistreringService)
 
     routing {
         swagger()

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
@@ -16,9 +16,7 @@ data class Bygning(
     val vannforsyning: Vannforsyning? = null,
     val avlop: Avlop? = null,
 ) {
-    fun withEgenregistrertData(bygningRegistrering: BygningRegistrering): Bygning {
-        val registreringstidspunkt = bygningRegistrering.registreringstidspunkt
-
+    fun withEgenregistrertData(registreringstidspunkt: Instant, bygningRegistrering: BygningRegistrering): Bygning {
         return this.copy(
             byggeaar = bygningRegistrering.byggeaarRegistrering?.byggeaar?.let {
                 Byggeaar(
@@ -77,8 +75,7 @@ data class Bruksenhet(
     val energikilder: List<Energikilde> = emptyList(),
     val oppvarminger: List<Oppvarming> = emptyList(),
 ) {
-    fun withEgenregistrertData(bruksenhetRegistrering: BruksenhetRegistrering): Bruksenhet {
-        val registreringstidspunkt = bruksenhetRegistrering.registreringstidspunkt
+    fun withEgenregistrertData(registreringstidspunkt: Instant, bruksenhetRegistrering: BruksenhetRegistrering): Bruksenhet {
         return this.copy(
             bruksareal = bruksenhetRegistrering.bruksarealRegistrering?.bruksareal?.let {
                 Bruksareal(

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
@@ -20,7 +20,7 @@ data class Bygning(
         return egenregistreringer.fold(this) { bygningAggregate, egenregistrering ->
             Bygning(
                 bygningId = bygningAggregate.bygningId,
-                bygningNummer = bygningAggregate.bygningNummer,
+                bygningsnummer = bygningAggregate.bygningsnummer,
                 bruksenheter = bygningAggregate.bruksenheter,
                 byggeaar = bygningAggregate.byggeaar ?: if (egenregistrering.bygningRegistrering.byggeaarRegistrering != null) {
                     Byggeaar(

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
@@ -16,49 +16,6 @@ data class Bygning(
     val vannforsyning: Vannforsyning? = null,
     val avlop: Avlop? = null,
 ) {
-    fun withEgenregistrertData(egenregistreringer: List<Egenregistrering>): Bygning {
-        return egenregistreringer.fold(this) { bygningAggregate, egenregistrering ->
-            Bygning(
-                bygningId = bygningAggregate.bygningId,
-                bygningsnummer = bygningAggregate.bygningsnummer,
-                bruksenheter = bygningAggregate.bruksenheter,
-                byggeaar = bygningAggregate.byggeaar ?: if (egenregistrering.bygningRegistrering.byggeaarRegistrering != null) {
-                    Byggeaar(
-                        data = egenregistrering.bygningRegistrering.byggeaarRegistrering.byggeaar,
-                        metadata = RegisterMetadata(
-                            registreringstidspunkt = egenregistrering.registreringstidspunkt,
-                        ),
-                    )
-                } else null,
-                bruksareal = bygningAggregate.bruksareal ?: if (egenregistrering.bygningRegistrering.bruksarealRegistrering != null) {
-                    Bruksareal(
-                        data = egenregistrering.bygningRegistrering.bruksarealRegistrering.bruksareal,
-                        metadata = RegisterMetadata(
-                            registreringstidspunkt = egenregistrering.registreringstidspunkt,
-                        ),
-                    )
-                } else null,
-                vannforsyning = bygningAggregate.vannforsyning
-                    ?: if (egenregistrering.bygningRegistrering.vannforsyningRegistrering != null) {
-                        Vannforsyning(
-                            data = egenregistrering.bygningRegistrering.vannforsyningRegistrering.vannforsyning,
-                            metadata = RegisterMetadata(
-                                registreringstidspunkt = egenregistrering.registreringstidspunkt,
-                            ),
-                        )
-                    } else null,
-                avlop = bygningAggregate.avlop ?: if (egenregistrering.bygningRegistrering.avlopRegistrering != null) {
-                    Avlop(
-                        data = egenregistrering.bygningRegistrering.avlopRegistrering.avlop,
-                        metadata = RegisterMetadata(
-                            registreringstidspunkt = egenregistrering.registreringstidspunkt,
-                        ),
-                    )
-                } else null,
-            )
-        }
-    }
-
     fun withBruksenheter(bruksenheter: List<Bruksenhet>): Bygning {
         return this.copy(
             bruksenheter = bruksenheter,
@@ -80,60 +37,4 @@ data class Bruksenhet(
     val bruksareal: Bruksareal? = null,
     val energikilder: List<Energikilde> = emptyList(),
     val oppvarminger: List<Oppvarming> = emptyList(),
-) {
-    fun withEgenregistrertData(egenregistreringer: List<Egenregistrering>): Bruksenhet {
-        // Her så antar jeg at man bare har registrert bruksenheten én gang per registrering, som gir mening
-        // Likevel har vi ikke noen logisk sjekk på dette ved registrering, så det bør vi nok ha
-        val bruksenhetRegistreringer = egenregistreringer.mapNotNull { egenregistrering ->
-            val bruksenhetRegistrering =
-                egenregistrering.bygningRegistrering.bruksenhetRegistreringer.filter { it.bruksenhetId == this.bruksenhetId }
-                    .firstOrNull()
-
-            if (bruksenhetRegistrering != null) {
-                egenregistrering.registreringstidspunkt to bruksenhetRegistrering
-            } else {
-                null
-            }
-        }
-
-        // Jeg er litt usikker på om det er nødvendig å filtrere ut og lage et Pair, så folde på bare bruksenhetregistreringene
-        // fremfor å gjøre det på hele bygningregistreringen dersom vi legger til logikk for å kun godkjenne én registrering
-        return bruksenhetRegistreringer.fold(this) { bruksenhetAggregate, egenregistrering ->
-            Bruksenhet(
-                bruksenhetId = bruksenhetAggregate.bruksenhetId,
-                bygningId = bruksenhetAggregate.bygningId,
-                bruksareal = bruksenhetAggregate.bruksareal ?: if (egenregistrering.second.bruksarealRegistrering != null) {
-                    Bruksareal(
-                        // ser ikke ut som kotlin skjønner at bruksarealRegistrering ikke er null her
-                        data = egenregistrering.second.bruksarealRegistrering!!.bruksareal,
-                        metadata = RegisterMetadata(
-                            registreringstidspunkt = egenregistrering.first,
-                        ),
-                    )
-                } else null,
-                energikilder = bruksenhetAggregate.energikilder.takeIf { it.isNotEmpty() }
-                    ?: if (egenregistrering.second.energikildeRegistrering?.energikilder?.isNotEmpty() == true) {
-                        egenregistrering.second.energikildeRegistrering!!.energikilder.map { registrertKilde ->
-                            Energikilde(
-                                data = registrertKilde,
-                                metadata = RegisterMetadata(
-                                    registreringstidspunkt = egenregistrering.first,
-                                ),
-                            )
-                        }
-                    } else emptyList(),
-                oppvarminger = bruksenhetAggregate.oppvarminger.takeIf { it.isNotEmpty() }
-                    ?: if (egenregistrering.second.oppvarmingRegistrering?.oppvarminger?.isNotEmpty() == true) {
-                        egenregistrering.second.oppvarmingRegistrering!!.oppvarminger.map { registrertOppvarming ->
-                            Oppvarming(
-                                data = registrertOppvarming,
-                                metadata = RegisterMetadata(
-                                    registreringstidspunkt = egenregistrering.first,
-                                ),
-                            )
-                        }
-                    } else emptyList(),
-            )
-        }
-    }
-}
+)

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
@@ -16,41 +16,47 @@ data class Bygning(
     val vannforsyning: Vannforsyning? = null,
     val avlop: Avlop? = null,
 ) {
-    fun withEgenregistrertData(registreringstidspunkt: Instant, bygningRegistrering: BygningRegistrering): Bygning {
-        return this.copy(
-            byggeaar = bygningRegistrering.byggeaarRegistrering?.byggeaar?.let {
-                Byggeaar(
-                    data = it,
-                    metadata = RegisterMetadata(
-                        registreringstidspunkt = registreringstidspunkt,
-                    ),
-                )
-            },
-            bruksareal = bygningRegistrering.bruksarealRegistrering?.bruksareal?.let {
-                Bruksareal(
-                    data = it,
-                    metadata = RegisterMetadata(
-                        registreringstidspunkt = registreringstidspunkt,
-                    ),
-                )
-            },
-            vannforsyning = bygningRegistrering.vannforsyningRegistrering?.vannforsyning?.let {
-                Vannforsyning(
-                    data = it,
-                    metadata = RegisterMetadata(
-                        registreringstidspunkt = registreringstidspunkt,
-                    ),
-                )
-            },
-            avlop = bygningRegistrering.avlopRegistrering?.avlop?.let {
-                Avlop(
-                    data = it,
-                    metadata = RegisterMetadata(
-                        registreringstidspunkt = registreringstidspunkt,
-                    ),
-                )
-            },
-        )
+    fun withEgenregistrertData(egenregistreringer: List<Egenregistrering>): Bygning {
+        return egenregistreringer.fold(this) { bygningAggregate, egenregistrering ->
+            Bygning(
+                bygningId = bygningAggregate.bygningId,
+                bygningNummer = bygningAggregate.bygningNummer,
+                bruksenheter = bygningAggregate.bruksenheter,
+                byggeaar = bygningAggregate.byggeaar ?: if (egenregistrering.bygningRegistrering.byggeaarRegistrering != null) {
+                    Byggeaar(
+                        data = egenregistrering.bygningRegistrering.byggeaarRegistrering.byggeaar,
+                        metadata = RegisterMetadata(
+                            registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                        ),
+                    )
+                } else null,
+                bruksareal = bygningAggregate.bruksareal ?: if (egenregistrering.bygningRegistrering.bruksarealRegistrering != null) {
+                    Bruksareal(
+                        data = egenregistrering.bygningRegistrering.bruksarealRegistrering.bruksareal,
+                        metadata = RegisterMetadata(
+                            registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                        ),
+                    )
+                } else null,
+                vannforsyning = bygningAggregate.vannforsyning
+                    ?: if (egenregistrering.bygningRegistrering.vannforsyningRegistrering != null) {
+                        Vannforsyning(
+                            data = egenregistrering.bygningRegistrering.vannforsyningRegistrering.vannforsyning,
+                            metadata = RegisterMetadata(
+                                registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                            ),
+                        )
+                    } else null,
+                avlop = bygningAggregate.avlop ?: if (egenregistrering.bygningRegistrering.avlopRegistrering != null) {
+                    Avlop(
+                        data = egenregistrering.bygningRegistrering.avlopRegistrering.avlop,
+                        metadata = RegisterMetadata(
+                            registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                        ),
+                    )
+                } else null,
+            )
+        }
     }
 
     fun withBruksenheter(bruksenheter: List<Bruksenhet>): Bygning {
@@ -75,32 +81,59 @@ data class Bruksenhet(
     val energikilder: List<Energikilde> = emptyList(),
     val oppvarminger: List<Oppvarming> = emptyList(),
 ) {
-    fun withEgenregistrertData(registreringstidspunkt: Instant, bruksenhetRegistrering: BruksenhetRegistrering): Bruksenhet {
-        return this.copy(
-            bruksareal = bruksenhetRegistrering.bruksarealRegistrering?.bruksareal?.let {
-                Bruksareal(
-                    data = it,
-                    metadata = RegisterMetadata(
-                        registreringstidspunkt = registreringstidspunkt,
-                    ),
-                )
-            },
-            energikilder = bruksenhetRegistrering.energikildeRegistrering?.energikilder?.map {
-                Energikilde(
-                    data = it,
-                    metadata = RegisterMetadata(
-                        registreringstidspunkt = registreringstidspunkt,
-                    ),
-                )
-            } ?: emptyList(),
-            oppvarminger = bruksenhetRegistrering.oppvarmingRegistrering?.oppvarminger?.map {
-                Oppvarming(
-                    data = it,
-                    metadata = RegisterMetadata(
-                        registreringstidspunkt = registreringstidspunkt,
-                    ),
-                )
-            } ?: emptyList(),
-        )
+    fun withEgenregistrertData(egenregistreringer: List<Egenregistrering>): Bruksenhet {
+        // Her så antar jeg at man bare har registrert bruksenheten én gang per registrering, som gir mening
+        // Likevel har vi ikke noen logisk sjekk på dette ved registrering, så det bør vi nok ha
+        val bruksenhetRegistreringer = egenregistreringer.mapNotNull { egenregistrering ->
+            val bruksenhetRegistrering =
+                egenregistrering.bygningRegistrering.bruksenhetRegistreringer.filter { it.bruksenhetId == this.bruksenhetId }
+                    .firstOrNull()
+
+            if (bruksenhetRegistrering != null) {
+                egenregistrering.registreringstidspunkt to bruksenhetRegistrering
+            } else {
+                null
+            }
+        }
+
+        // Jeg er litt usikker på om det er nødvendig å filtrere ut og lage et Pair, så folde på bare bruksenhetregistreringene
+        // fremfor å gjøre det på hele bygningregistreringen dersom vi legger til logikk for å kun godkjenne én registrering
+        return bruksenhetRegistreringer.fold(this) { bruksenhetAggregate, egenregistrering ->
+            Bruksenhet(
+                bruksenhetId = bruksenhetAggregate.bruksenhetId,
+                bygningId = bruksenhetAggregate.bygningId,
+                bruksareal = bruksenhetAggregate.bruksareal ?: if (egenregistrering.second.bruksarealRegistrering != null) {
+                    Bruksareal(
+                        // ser ikke ut som kotlin skjønner at bruksarealRegistrering ikke er null her
+                        data = egenregistrering.second.bruksarealRegistrering!!.bruksareal,
+                        metadata = RegisterMetadata(
+                            registreringstidspunkt = egenregistrering.first,
+                        ),
+                    )
+                } else null,
+                energikilder = bruksenhetAggregate.energikilder.takeIf { it.isNotEmpty() }
+                    ?: if (egenregistrering.second.energikildeRegistrering?.energikilder?.isNotEmpty() == true) {
+                        egenregistrering.second.energikildeRegistrering!!.energikilder.map { registrertKilde ->
+                            Energikilde(
+                                data = registrertKilde,
+                                metadata = RegisterMetadata(
+                                    registreringstidspunkt = egenregistrering.first,
+                                ),
+                            )
+                        }
+                    } else emptyList(),
+                oppvarminger = bruksenhetAggregate.oppvarminger.takeIf { it.isNotEmpty() }
+                    ?: if (egenregistrering.second.oppvarmingRegistrering?.oppvarminger?.isNotEmpty() == true) {
+                        egenregistrering.second.oppvarmingRegistrering!!.oppvarminger.map { registrertOppvarming ->
+                            Oppvarming(
+                                data = registrertOppvarming,
+                                metadata = RegisterMetadata(
+                                    registreringstidspunkt = egenregistrering.first,
+                                ),
+                            )
+                        }
+                    } else emptyList(),
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensions.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensions.kt
@@ -11,39 +11,38 @@ fun Bygning.withEgenregistrertData(egenregistreringer: List<Egenregistrering>): 
             bygningId = bygningAggregate.bygningId,
             bygningsnummer = bygningAggregate.bygningsnummer,
             bruksenheter = bygningAggregate.bruksenheter,
-            byggeaar = bygningAggregate.byggeaar ?: if (egenregistrering.bygningRegistrering.byggeaarRegistrering != null) {
+            byggeaar = bygningAggregate.byggeaar ?: egenregistrering.bygningRegistrering.byggeaarRegistrering?.let {
                 Byggeaar(
-                    data = egenregistrering.bygningRegistrering.byggeaarRegistrering.byggeaar,
+                    data = it.byggeaar,
                     metadata = RegisterMetadata(
                         registreringstidspunkt = egenregistrering.registreringstidspunkt,
                     ),
                 )
-            } else null,
-            bruksareal = bygningAggregate.bruksareal ?: if (egenregistrering.bygningRegistrering.bruksarealRegistrering != null) {
+            },
+            bruksareal = bygningAggregate.bruksareal ?: egenregistrering.bygningRegistrering.bruksarealRegistrering?.let {
                 Bruksareal(
-                    data = egenregistrering.bygningRegistrering.bruksarealRegistrering.bruksareal,
+                    data = it.bruksareal,
                     metadata = RegisterMetadata(
                         registreringstidspunkt = egenregistrering.registreringstidspunkt,
                     ),
                 )
-            } else null,
-            vannforsyning = bygningAggregate.vannforsyning
-                ?: if (egenregistrering.bygningRegistrering.vannforsyningRegistrering != null) {
-                    Vannforsyning(
-                        data = egenregistrering.bygningRegistrering.vannforsyningRegistrering.vannforsyning,
-                        metadata = RegisterMetadata(
-                            registreringstidspunkt = egenregistrering.registreringstidspunkt,
-                        ),
-                    )
-                } else null,
-            avlop = bygningAggregate.avlop ?: if (egenregistrering.bygningRegistrering.avlopRegistrering != null) {
+            },
+            vannforsyning = bygningAggregate.vannforsyning ?: egenregistrering.bygningRegistrering.vannforsyningRegistrering?.let {
+                Vannforsyning(
+                    data = it.vannforsyning,
+                    metadata = RegisterMetadata(
+                        registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                    ),
+                )
+            },
+            avlop = bygningAggregate.avlop ?: egenregistrering.bygningRegistrering.avlopRegistrering?.let {
                 Avlop(
-                    data = egenregistrering.bygningRegistrering.avlopRegistrering.avlop,
+                    data = it.avlop,
                     metadata = RegisterMetadata(
                         registreringstidspunkt = egenregistrering.registreringstidspunkt,
                     ),
                 )
-            } else null,
+            },
         )
     }
 }
@@ -54,8 +53,7 @@ fun Bruksenhet.withEgenregistrertData(egenregistreringer: List<Egenregistrering>
     // Likevel har vi ikke noen logisk sjekk på dette ved registrering, så det bør vi nok ha
     val bruksenhetRegistreringer = egenregistreringer.mapNotNull { egenregistrering ->
         val bruksenhetRegistrering =
-            egenregistrering.bygningRegistrering.bruksenhetRegistreringer.filter { it.bruksenhetId == this.bruksenhetId }
-                .firstOrNull()
+            egenregistrering.bygningRegistrering.bruksenhetRegistreringer.filter { it.bruksenhetId == this.bruksenhetId }.firstOrNull()
 
         if (bruksenhetRegistrering != null) {
             egenregistrering.registreringstidspunkt to bruksenhetRegistrering
@@ -70,18 +68,17 @@ fun Bruksenhet.withEgenregistrertData(egenregistreringer: List<Egenregistrering>
         Bruksenhet(
             bruksenhetId = bruksenhetAggregate.bruksenhetId,
             bygningId = bruksenhetAggregate.bygningId,
-            bruksareal = bruksenhetAggregate.bruksareal ?: if (egenregistrering.second.bruksarealRegistrering != null) {
+            bruksareal = bruksenhetAggregate.bruksareal ?: egenregistrering.second.bruksarealRegistrering?.let {
                 Bruksareal(
-                    // ser ikke ut som kotlin skjønner at bruksarealRegistrering ikke er null her
-                    data = egenregistrering.second.bruksarealRegistrering!!.bruksareal,
+                    data = it.bruksareal,
                     metadata = RegisterMetadata(
                         registreringstidspunkt = egenregistrering.first,
                     ),
                 )
-            } else null,
+            },
             energikilder = bruksenhetAggregate.energikilder.takeIf { it.isNotEmpty() }
-                ?: if (egenregistrering.second.energikildeRegistrering?.energikilder?.isNotEmpty() == true) {
-                    egenregistrering.second.energikildeRegistrering!!.energikilder.map { registrertKilde ->
+                ?: egenregistrering.second.energikildeRegistrering?.let {
+                    it.energikilder.map { registrertKilde ->
                         Energikilde(
                             data = registrertKilde,
                             metadata = RegisterMetadata(
@@ -89,10 +86,10 @@ fun Bruksenhet.withEgenregistrertData(egenregistreringer: List<Egenregistrering>
                             ),
                         )
                     }
-                } else emptyList(),
+                } ?: emptyList(),
             oppvarminger = bruksenhetAggregate.oppvarminger.takeIf { it.isNotEmpty() }
-                ?: if (egenregistrering.second.oppvarmingRegistrering?.oppvarminger?.isNotEmpty() == true) {
-                    egenregistrering.second.oppvarmingRegistrering!!.oppvarminger.map { registrertOppvarming ->
+                ?: egenregistrering.second.oppvarmingRegistrering?.let {
+                    it.oppvarminger.map { registrertOppvarming ->
                         Oppvarming(
                             data = registrertOppvarming,
                             metadata = RegisterMetadata(
@@ -100,7 +97,7 @@ fun Bruksenhet.withEgenregistrertData(egenregistreringer: List<Egenregistrering>
                             ),
                         )
                     }
-                } else emptyList(),
+                } ?: emptyList(),
         )
     }
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensions.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensions.kt
@@ -1,0 +1,106 @@
+package no.kartverket.matrikkel.bygning.models
+
+/**
+ * Burde vi kanskje sortere egenregistreringer her, da vi er avhengig av at egenregistreringene er sortert her,
+ * men ikke nødvendigvis andre steder?
+ */
+
+fun Bygning.withEgenregistrertData(egenregistreringer: List<Egenregistrering>): Bygning {
+    return egenregistreringer.fold(this) { bygningAggregate, egenregistrering ->
+        Bygning(
+            bygningId = bygningAggregate.bygningId,
+            bygningsnummer = bygningAggregate.bygningsnummer,
+            bruksenheter = bygningAggregate.bruksenheter,
+            byggeaar = bygningAggregate.byggeaar ?: if (egenregistrering.bygningRegistrering.byggeaarRegistrering != null) {
+                Byggeaar(
+                    data = egenregistrering.bygningRegistrering.byggeaarRegistrering.byggeaar,
+                    metadata = RegisterMetadata(
+                        registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                    ),
+                )
+            } else null,
+            bruksareal = bygningAggregate.bruksareal ?: if (egenregistrering.bygningRegistrering.bruksarealRegistrering != null) {
+                Bruksareal(
+                    data = egenregistrering.bygningRegistrering.bruksarealRegistrering.bruksareal,
+                    metadata = RegisterMetadata(
+                        registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                    ),
+                )
+            } else null,
+            vannforsyning = bygningAggregate.vannforsyning
+                ?: if (egenregistrering.bygningRegistrering.vannforsyningRegistrering != null) {
+                    Vannforsyning(
+                        data = egenregistrering.bygningRegistrering.vannforsyningRegistrering.vannforsyning,
+                        metadata = RegisterMetadata(
+                            registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                        ),
+                    )
+                } else null,
+            avlop = bygningAggregate.avlop ?: if (egenregistrering.bygningRegistrering.avlopRegistrering != null) {
+                Avlop(
+                    data = egenregistrering.bygningRegistrering.avlopRegistrering.avlop,
+                    metadata = RegisterMetadata(
+                        registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                    ),
+                )
+            } else null,
+        )
+    }
+}
+
+
+fun Bruksenhet.withEgenregistrertData(egenregistreringer: List<Egenregistrering>): Bruksenhet {
+    // Her så antar jeg at man bare har registrert bruksenheten én gang per registrering, som gir mening
+    // Likevel har vi ikke noen logisk sjekk på dette ved registrering, så det bør vi nok ha
+    val bruksenhetRegistreringer = egenregistreringer.mapNotNull { egenregistrering ->
+        val bruksenhetRegistrering =
+            egenregistrering.bygningRegistrering.bruksenhetRegistreringer.filter { it.bruksenhetId == this.bruksenhetId }
+                .firstOrNull()
+
+        if (bruksenhetRegistrering != null) {
+            egenregistrering.registreringstidspunkt to bruksenhetRegistrering
+        } else {
+            null
+        }
+    }
+
+    // Jeg er litt usikker på om det er nødvendig å filtrere ut og lage et Pair, så folde på bare bruksenhetregistreringene
+    // fremfor å gjøre det på hele bygningregistreringen dersom vi legger til logikk for å kun godkjenne én registrering
+    return bruksenhetRegistreringer.fold(this) { bruksenhetAggregate, egenregistrering ->
+        Bruksenhet(
+            bruksenhetId = bruksenhetAggregate.bruksenhetId,
+            bygningId = bruksenhetAggregate.bygningId,
+            bruksareal = bruksenhetAggregate.bruksareal ?: if (egenregistrering.second.bruksarealRegistrering != null) {
+                Bruksareal(
+                    // ser ikke ut som kotlin skjønner at bruksarealRegistrering ikke er null her
+                    data = egenregistrering.second.bruksarealRegistrering!!.bruksareal,
+                    metadata = RegisterMetadata(
+                        registreringstidspunkt = egenregistrering.first,
+                    ),
+                )
+            } else null,
+            energikilder = bruksenhetAggregate.energikilder.takeIf { it.isNotEmpty() }
+                ?: if (egenregistrering.second.energikildeRegistrering?.energikilder?.isNotEmpty() == true) {
+                    egenregistrering.second.energikildeRegistrering!!.energikilder.map { registrertKilde ->
+                        Energikilde(
+                            data = registrertKilde,
+                            metadata = RegisterMetadata(
+                                registreringstidspunkt = egenregistrering.first,
+                            ),
+                        )
+                    }
+                } else emptyList(),
+            oppvarminger = bruksenhetAggregate.oppvarminger.takeIf { it.isNotEmpty() }
+                ?: if (egenregistrering.second.oppvarmingRegistrering?.oppvarminger?.isNotEmpty() == true) {
+                    egenregistrering.second.oppvarmingRegistrering!!.oppvarminger.map { registrertOppvarming ->
+                        Oppvarming(
+                            data = registrertOppvarming,
+                            metadata = RegisterMetadata(
+                                registreringstidspunkt = egenregistrering.first,
+                            ),
+                        )
+                    }
+                } else emptyList(),
+        )
+    }
+}

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Egenregistrering.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Egenregistrering.kt
@@ -5,8 +5,6 @@ import no.kartverket.matrikkel.bygning.models.kodelister.AvlopKode
 import no.kartverket.matrikkel.bygning.models.kodelister.EnergikildeKode
 import no.kartverket.matrikkel.bygning.models.kodelister.OppvarmingKode
 import no.kartverket.matrikkel.bygning.models.kodelister.VannforsyningKode
-import no.kartverket.matrikkel.bygning.serializers.InstantSerializer
-import no.kartverket.matrikkel.bygning.serializers.UUIDSerializer
 import java.time.Instant
 import java.util.*
 
@@ -40,44 +38,28 @@ data class OppvarmingRegistrering(
     val oppvarminger: List<OppvarmingKode>,
 )
 
-sealed interface Registrering {
-    val registreringId: UUID
-    val registreringstidspunkt: Instant
-    val bruksarealRegistrering: BruksarealRegistrering?
-}
 
 @Serializable
 data class BygningRegistrering(
-    @Serializable(with = UUIDSerializer::class)
-    override val registreringId: UUID,
     val bygningId: Long,
-    override val bruksarealRegistrering: BruksarealRegistrering?,
+    val bruksarealRegistrering: BruksarealRegistrering?,
     val byggeaarRegistrering: ByggeaarRegistrering?,
     val vannforsyningRegistrering: VannforsyningRegistrering?,
     val avlopRegistrering: AvlopRegistrering?,
-    @Serializable(with = InstantSerializer::class)
-    override val registreringstidspunkt: Instant,
-) : Registrering
+    val bruksenhetRegistreringer: List<BruksenhetRegistrering>
+)
 
 @Serializable
 data class BruksenhetRegistrering(
-    @Serializable(with = UUIDSerializer::class)
-    override val registreringId: UUID,
     val bruksenhetId: Long,
-    override val bruksarealRegistrering: BruksarealRegistrering?,
+    val bruksarealRegistrering: BruksarealRegistrering?,
     val energikildeRegistrering: EnergikildeRegistrering?,
     val oppvarmingRegistrering: OppvarmingRegistrering?,
-    @Serializable(with = InstantSerializer::class)
-    override val registreringstidspunkt: Instant,
-) : Registrering
+)
 
-// Ikke så fan av at egenregistrering har bygningID på toppnivå, og en bygning også har bygningId
-// Per nå trenger man det for at bygningRegistreringer kan hentes opp på bygningId, samt at man må hente riktig bygning og bruksenheter
-// når man egenregistrerer bruksenheter
+
 data class Egenregistrering(
     val id: UUID,
     val registreringstidspunkt: Instant,
-    val bygningId: Long,
-    val bygningRegistrering: BygningRegistrering?,
-    val bruksenhetRegistreringer: List<BruksenhetRegistrering>?
+    val bygningRegistrering: BygningRegistrering,
 )

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepository.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepository.kt
@@ -1,91 +1,52 @@
 package no.kartverket.matrikkel.bygning.repositories
 
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import no.kartverket.matrikkel.bygning.db.executeQueryAndMapPreparedStatement
 import no.kartverket.matrikkel.bygning.db.prepareAndExecuteUpdate
-import no.kartverket.matrikkel.bygning.db.prepareBatchAndExecuteUpdate
 import no.kartverket.matrikkel.bygning.db.withTransaction
-import no.kartverket.matrikkel.bygning.models.BruksenhetRegistrering
 import no.kartverket.matrikkel.bygning.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.models.Egenregistrering
-import no.kartverket.matrikkel.bygning.models.Registrering
 import no.kartverket.matrikkel.bygning.models.Result
 import org.postgresql.util.PGobject
-import java.sql.PreparedStatement
 import java.sql.Timestamp
 import java.util.UUID
 import javax.sql.DataSource
 
 class EgenregistreringRepository(private val dataSource: DataSource) {
-    fun findNewestBruksenhetRegistrering(bruksenhetId: Long): BruksenhetRegistrering? {
-        return findNewestRegistrering<BruksenhetRegistrering>(bruksenhetId)
-    }
-
-    fun findNewestBygningRegistrering(bygningId: Long): BygningRegistrering? {
-        return findNewestRegistrering<BygningRegistrering>(bygningId)
-    }
-
-    private inline fun <reified T : Registrering> findNewestRegistrering(id: Long): T? {
-        val idName = when (T::class) {
-            BygningRegistrering::class -> "bygningId"
-            BruksenhetRegistrering::class -> "bruksenhetId"
-            else -> null
-        } ?: throw RuntimeException("Det ble forsøkt å hente registrering med feil type, ${T::class}")
-
+    fun getAllEgenregistreringerForBygning(bygningId: Long): List<Egenregistrering> {
         return dataSource.executeQueryAndMapPreparedStatement(
             """
-                select r.registrering, e.registrering_tidspunkt
-                from bygning.registrering r
-                    left join bygning.egenregistrering e on e.id = r.egenregistrering_id
-                where r.registrering ->> ? = ?
-                order by e.registrering_tidspunkt DESC
-                limit 1;
+                select er.id, er.registrering_tidspunkt as registreringstidspunkt, er.registrering as bygningregistrering
+                from bygning.egenregistrering er
+                where er.registrering ->> 'bygningId' = ?
+                order by er.registrering_tidspunkt DESC;
             """.trimIndent(),
             {
-                it.setString(1, idName)
-                it.setString(2, id.toString())
+                it.setString(1, bygningId.toString())
             },
         ) {
-            Json.decodeFromString<T>(it.getString("registrering"))
-        }.firstOrNull()
+            Egenregistrering(
+                id = UUID.fromString(it.getString("id")),
+                registreringstidspunkt = it.getTimestamp("registreringstidspunkt").toInstant(),
+                bygningRegistrering = Json.decodeFromString<BygningRegistrering>(it.getString("bygningregistrering")),
+            )
+        }
     }
 
     fun saveEgenregistrering(egenregistrering: Egenregistrering): Result<Unit> {
         return dataSource.withTransaction { connection ->
             connection.prepareAndExecuteUpdate(
-                "INSERT INTO bygning.egenregistrering values (?, ?)",
+                "INSERT INTO bygning.egenregistrering values (?, ?, ?)",
             ) {
                 it.setObject(1, egenregistrering.id)
                 it.setTimestamp(2, Timestamp.from(egenregistrering.registreringstidspunkt))
+                it.setObject(3, PGobject().apply {
+                    this.type = "jsonb"
+                    // Av en eller annen grunn må jeg eksplisitt nevne serializer typen her
+                    this.value =
+                        Json.encodeToString(BygningRegistrering.serializer(), egenregistrering.bygningRegistrering)
+                })
             }
-
-            connection.prepareBatchAndExecuteUpdate(
-                "INSERT INTO bygning.registrering values (?, ?, ?)",
-                buildList {
-                    egenregistrering.bygningRegistrering?.let { bygningRegistrering ->
-                        add(createRegistreringBatchSetter(egenregistrering.id, bygningRegistrering))
-                    }
-
-                    egenregistrering.bruksenhetRegistreringer?.forEach { bruksenhetRegistrering ->
-                        add(createRegistreringBatchSetter(egenregistrering.id, bruksenhetRegistrering))
-                    }
-                },
-            )
         }
-    }
-
-    private inline fun <reified T : Registrering> createRegistreringBatchSetter(
-        egenregistreringId: UUID, registrering: T
-    ): (PreparedStatement) -> Unit = { preparedStatement ->
-        preparedStatement.setObject(1, registrering.registreringId)
-        preparedStatement.setObject(2, egenregistreringId)
-        preparedStatement.setObject(
-            3,
-            PGobject().apply {
-                this.type = "jsonb"
-                this.value = Json.encodeToString(registrering)
-            },
-        )
     }
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepository.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepository.kt
@@ -16,10 +16,10 @@ class EgenregistreringRepository(private val dataSource: DataSource) {
     fun getAllEgenregistreringerForBygning(bygningId: Long): List<Egenregistrering> {
         return dataSource.executeQueryAndMapPreparedStatement(
             """
-                select er.id, er.registrering_tidspunkt as registreringstidspunkt, er.registrering as bygningregistrering
+                select er.id, er.registreringstidspunkt, er.registrering as bygningregistrering
                 from bygning.egenregistrering er
                 where er.registrering ->> 'bygningId' = ?
-                order by er.registrering_tidspunkt DESC;
+                order by er.registreringstidspunkt DESC;
             """.trimIndent(),
             {
                 it.setString(1, bygningId.toString())

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/dto/request/EgenregistreringRequest.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/dto/request/EgenregistreringRequest.kt
@@ -42,25 +42,20 @@ fun EgenregistreringRequest.toEgenregistrering(): Egenregistrering {
     return Egenregistrering(
         id = UUID.randomUUID(),
         registreringstidspunkt = registreringstidspunkt,
-        bygningId = this.bygningId,
         bygningRegistrering = BygningRegistrering(
-                registreringId = UUID.randomUUID(),
-                bygningId = this.bygningId,
-                byggeaarRegistrering = this.bygningRegistrering?.byggeaarRegistrering,
-                bruksarealRegistrering = this.bygningRegistrering?.bruksarealRegistrering,
-                vannforsyningRegistrering = this.bygningRegistrering?.vannforsyningRegistrering,
-                avlopRegistrering = this.bygningRegistrering?.avlopRegistrering,
-                registreringstidspunkt = registreringstidspunkt,
-        ),
-        bruksenhetRegistreringer = this.bruksenhetRegistreringer?.map { bruksenhetRegistrering ->
-            BruksenhetRegistrering(
-                    registreringId = UUID.randomUUID(),
+            bygningId = this.bygningId,
+            byggeaarRegistrering = this.bygningRegistrering?.byggeaarRegistrering,
+            bruksarealRegistrering = this.bygningRegistrering?.bruksarealRegistrering,
+            vannforsyningRegistrering = this.bygningRegistrering?.vannforsyningRegistrering,
+            avlopRegistrering = this.bygningRegistrering?.avlopRegistrering,
+            bruksenhetRegistreringer = this.bruksenhetRegistreringer?.map { bruksenhetRegistrering ->
+                BruksenhetRegistrering(
                     bruksenhetId = bruksenhetRegistrering.bruksenhetId,
                     bruksarealRegistrering = bruksenhetRegistrering.bruksarealRegistrering,
                     energikildeRegistrering = bruksenhetRegistrering.energikildeRegistrering,
                     oppvarmingRegistrering = bruksenhetRegistrering.oppvarmingRegistrering,
-                    registreringstidspunkt = registreringstidspunkt,
-            )
-        },
+                )
+            } ?: emptyList(),
+        ),
     )
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/services/BygningService.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/services/BygningService.kt
@@ -36,8 +36,9 @@ class BygningService(
             ),
         )
 
-        val bruksenhet = bygning.bruksenheter.find { it.bruksenhetId == bruksenhetId }
-//            ?.let { addEgenregistrerteDataForBruksenhet(it) }
+        val egenregistreringerForBygning = egenregistreringService.findAllEgenregistreringerForBygning(bygningId)
+
+        val bruksenhet = bygning.bruksenheter.find { it.bruksenhetId == bruksenhetId }?.withEgenregistrertData(egenregistreringerForBygning)
             ?: return Result.ErrorResult(
                 ErrorDetail(
                     detail = "Bruksenhet finnes ikke på bygningen",

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/services/BygningService.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/services/BygningService.kt
@@ -5,6 +5,7 @@ import no.kartverket.matrikkel.bygning.models.Bruksenhet
 import no.kartverket.matrikkel.bygning.models.Bygning
 import no.kartverket.matrikkel.bygning.models.Result
 import no.kartverket.matrikkel.bygning.models.responses.ErrorDetail
+import no.kartverket.matrikkel.bygning.models.withEgenregistrertData
 
 class BygningService(
     private val bygningClient: BygningClient,

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/services/BygningService.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/services/BygningService.kt
@@ -5,11 +5,10 @@ import no.kartverket.matrikkel.bygning.models.Bruksenhet
 import no.kartverket.matrikkel.bygning.models.Bygning
 import no.kartverket.matrikkel.bygning.models.Result
 import no.kartverket.matrikkel.bygning.models.responses.ErrorDetail
-import no.kartverket.matrikkel.bygning.repositories.EgenregistreringRepository
 
 class BygningService(
     private val bygningClient: BygningClient,
-    private val egenregistreringRepository: EgenregistreringRepository,
+    private val egenregistreringService: EgenregistreringService,
 ) {
     fun getBygningWithEgenregistrertData(bygningId: Long): Result<Bygning> {
         val bygning = bygningClient.getBygningById(bygningId)
@@ -19,13 +18,25 @@ class BygningService(
                 ),
             )
 
-        // Burde disse heller komme fra egenregistreringService, i stedet for å sende inn egenregistreringRepository her?
-        val bygningWithEgenregistrertData = egenregistreringRepository.findNewestBygningRegistrering(bygningId)
-            ?.let { bygning.withEgenregistrertData(it) }
-            ?: bygning
+        val newestEgenregistrering = egenregistreringService.findNewestEgenregistreringForBygning(bygningId)
 
-        val bruksenheterWithEgenregistrertData = bygning.bruksenheter
-            .map(::addEgenregistrerteDataForBruksenhet)
+        val bygningWithEgenregistrertData = if (newestEgenregistrering != null) {
+            bygning.withEgenregistrertData(newestEgenregistrering.registreringstidspunkt, newestEgenregistrering.bygningRegistrering)
+        } else bygning
+
+        val bruksenheterWithEgenregistrertData = bygning.bruksenheter.map { bruksenhet ->
+            val bruksenhetRegistrering =
+                newestEgenregistrering?.bygningRegistrering?.bruksenhetRegistreringer?.find { it.bruksenhetId == bruksenhet.bruksenhetId }
+            if (bruksenhetRegistrering != null) {
+                bruksenhet.withEgenregistrertData(newestEgenregistrering.registreringstidspunkt, bruksenhetRegistrering)
+            } else bruksenhet
+        }
+
+
+        val egenregisteringerForBygning = egenregistreringService.findAllEgenregistreringerForBygning(bygningId)
+
+        val aggregatedBygningRegistrering =
+
 
         return Result.Success(bygningWithEgenregistrertData.withBruksenheter(bruksenheterWithEgenregistrertData))
 
@@ -41,7 +52,7 @@ class BygningService(
 
         val bruksenhet = bygning.bruksenheter
             .find { it.bruksenhetId == bruksenhetId }
-            ?.let { addEgenregistrerteDataForBruksenhet(it) }
+//            ?.let { addEgenregistrerteDataForBruksenhet(it) }
             ?: return Result.ErrorResult(
                 ErrorDetail(
                     detail = "Bruksenhet finnes ikke på bygningen",
@@ -49,12 +60,6 @@ class BygningService(
             )
 
         return Result.Success(bruksenhet)
-    }
-
-    private fun addEgenregistrerteDataForBruksenhet(bruksenhet: Bruksenhet): Bruksenhet {
-        return egenregistreringRepository.findNewestBruksenhetRegistrering(bruksenhet.bruksenhetId)
-            ?.let { bruksenhet.withEgenregistrertData(it) }
-            ?: bruksenhet
     }
 }
 

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/services/EgenregistreringService.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/services/EgenregistreringService.kt
@@ -46,8 +46,4 @@ class EgenregistreringService(
     fun findAllEgenregistreringerForBygning(bygningId: Long): List<Egenregistrering> {
         return egenregistreringRepository.getAllEgenregistreringerForBygning(bygningId)
     }
-
-    fun findNewestEgenregistreringForBygning(bygningId: Long): Egenregistrering? {
-        return findAllEgenregistreringerForBygning(bygningId).firstOrNull()
-    }
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/services/EgenregistreringService.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/services/EgenregistreringService.kt
@@ -11,10 +11,9 @@ class EgenregistreringService(
     private val bygningClient: BygningClient, private val egenregistreringRepository: EgenregistreringRepository
 ) {
     fun addEgenregistrering(egenregistrering: Egenregistrering): Result<Unit> {
-
-        val bygning = bygningClient.getBygningById(egenregistrering.bygningId) ?: return Result.ErrorResult(
+        val bygning = bygningClient.getBygningById(egenregistrering.bygningRegistrering.bygningId) ?: return Result.ErrorResult(
             ErrorDetail(
-                detail = "Bygning med ID ${egenregistrering.bygningId} finnes ikke i matrikkelen",
+                detail = "Bygning med ID ${egenregistrering.bygningRegistrering.bygningId} finnes ikke i matrikkelen",
             ),
         )
 
@@ -33,7 +32,7 @@ class EgenregistreringService(
     private fun findBruksenheterNotRegisteredOnCorrectBygning(
         egenregistrering: Egenregistrering, bygning: Bygning
     ): List<Long> {
-        return egenregistrering.bruksenhetRegistreringer?.mapNotNull { bruksenhetRegistering ->
+        return egenregistrering.bygningRegistrering.bruksenhetRegistreringer.mapNotNull { bruksenhetRegistering ->
             val bruksenhet = bygning.bruksenheter.find { it.bruksenhetId == bruksenhetRegistering.bruksenhetId }
 
             if (bruksenhet == null) {
@@ -41,6 +40,14 @@ class EgenregistreringService(
             } else {
                 null
             }
-        } ?: emptyList()
+        }
+    }
+
+    fun findAllEgenregistreringerForBygning(bygningId: Long): List<Egenregistrering> {
+        return egenregistreringRepository.getAllEgenregistreringerForBygning(bygningId)
+    }
+
+    fun findNewestEgenregistreringForBygning(bygningId: Long): Egenregistrering? {
+        return findAllEgenregistreringerForBygning(bygningId).firstOrNull()
     }
 }

--- a/src/main/resources/db/migration/V1__init_db.sql
+++ b/src/main/resources/db/migration/V1__init_db.sql
@@ -3,12 +3,12 @@ create schema if not exists bygning;
 CREATE TABLE egenregistrering
 (
     id                     UUID PRIMARY KEY,
-    registrering_tidspunkt TIMESTAMP WITH TIME ZONE NOT NULL
+    registrering_tidspunkt TIMESTAMP WITH TIME ZONE NOT NULL,
+    registrering           JSONB                    NOT NULL
 );
 
-CREATE TABLE registrering
-(
-    id                  UUID PRIMARY KEY,
-    egenregistrering_id UUID  NOT NULL REFERENCES egenregistrering (id),
-    registrering        JSONB NOT NULL
-);
+-- CREATE TABLE registrering
+-- (
+--     id                  UUID PRIMARY KEY,
+--     egenregistrering_id UUID  NOT NULL REFERENCES egenregistrering (id),
+-- );

--- a/src/main/resources/db/migration/V1__init_db.sql
+++ b/src/main/resources/db/migration/V1__init_db.sql
@@ -3,6 +3,6 @@ create schema if not exists bygning;
 CREATE TABLE egenregistrering
 (
     id                     UUID PRIMARY KEY,
-    registrering_tidspunkt TIMESTAMP WITH TIME ZONE NOT NULL,
+    registreringstidspunkt TIMESTAMP WITH TIME ZONE NOT NULL,
     registrering           JSONB                    NOT NULL
 );

--- a/src/main/resources/db/migration/V1__init_db.sql
+++ b/src/main/resources/db/migration/V1__init_db.sql
@@ -6,9 +6,3 @@ CREATE TABLE egenregistrering
     registrering_tidspunkt TIMESTAMP WITH TIME ZONE NOT NULL,
     registrering           JSONB                    NOT NULL
 );
-
--- CREATE TABLE registrering
--- (
---     id                  UUID PRIMARY KEY,
---     egenregistrering_id UUID  NOT NULL REFERENCES egenregistrering (id),
--- );

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensionsTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensionsTest.kt
@@ -16,19 +16,38 @@ class BygningExtensionsTest {
         avlop = null,
     )
 
+    val defaultBruksenhet = Bruksenhet(
+        bruksenhetId = 1L,
+        bygningId = 1L,
+        bruksareal = null,
+        energikilder = emptyList(),
+        oppvarminger = emptyList(),
+    )
+
+    val defaultBruksenhetRegistrering = BruksenhetRegistrering(
+        bruksenhetId = 1L,
+        bruksarealRegistrering = BruksarealRegistrering(
+            bruksareal = 50.0
+        ),
+        energikildeRegistrering = null,
+        oppvarmingRegistrering = null
+    )
+
+    val defaultBygningRegistrering = BygningRegistrering(
+        bygningId = 1L,
+        bruksarealRegistrering = BruksarealRegistrering(
+            bruksareal = 125.0,
+        ),
+        byggeaarRegistrering = null,
+        vannforsyningRegistrering = null,
+        avlopRegistrering = null,
+        bruksenhetRegistreringer = listOf(defaultBruksenhetRegistrering),
+    )
+
     val defaultEgenregistrering = Egenregistrering(
         id = UUID.randomUUID(),
         registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
-        bygningRegistrering = BygningRegistrering(
-            bygningId = 1L,
-            bruksarealRegistrering = BruksarealRegistrering(
-                bruksareal = 125.0,
-            ),
-            byggeaarRegistrering = null,
-            vannforsyningRegistrering = null,
-            avlopRegistrering = null,
-            bruksenhetRegistreringer = emptyList(),
-        ),
+        bygningRegistrering = defaultBygningRegistrering
     )
 
     @Test
@@ -46,5 +65,13 @@ class BygningExtensionsTest {
         val aggregatedBygning = defaultBygning.withEgenregistrertData(listOf(laterRegistrering, defaultEgenregistrering))
 
         assertThat(aggregatedBygning.bruksareal?.data).isEqualTo(150.0)
+    }
+
+    @Test
+    fun `registrering med tom liste paa listeregistering skal ikke sette felt paa bruksenhet`() {
+        val bruksenhet = defaultBruksenhet.withEgenregistrertData(listOf(defaultEgenregistrering))
+
+        assertThat(bruksenhet.oppvarminger).isEmpty()
+        assertThat(bruksenhet.energikilder).isEmpty()
     }
 }

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensionsTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensionsTest.kt
@@ -1,0 +1,50 @@
+package no.kartverket.matrikkel.bygning.models
+
+import org.assertj.core.api.Assertions.assertThat
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.Test
+
+class BygningExtensionsTest {
+    val defaultBygning = Bygning(
+        bygningId = 1L,
+        bygningsnummer = 100,
+        bruksenheter = emptyList(),
+        byggeaar = null,
+        bruksareal = null,
+        vannforsyning = null,
+        avlop = null,
+    )
+
+    val defaultEgenregistrering = Egenregistrering(
+        id = UUID.randomUUID(),
+        registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
+        bygningRegistrering = BygningRegistrering(
+            bygningId = 1L,
+            bruksarealRegistrering = BruksarealRegistrering(
+                bruksareal = 125.0,
+            ),
+            byggeaarRegistrering = null,
+            vannforsyningRegistrering = null,
+            avlopRegistrering = null,
+            bruksenhetRegistreringer = emptyList(),
+        ),
+    )
+
+    @Test
+    fun `bygning med to egenregistreringer paa ett felt skal kun gi nyeste feltet`() {
+        val laterRegistrering = defaultEgenregistrering.copy(
+            id = UUID.randomUUID(),
+            registreringstidspunkt = defaultEgenregistrering.registreringstidspunkt.plusSeconds(60),
+            bygningRegistrering = defaultEgenregistrering.bygningRegistrering.copy(
+                bruksarealRegistrering = BruksarealRegistrering(
+                    bruksareal = 150.0,
+                ),
+            ),
+        )
+
+        val aggregatedBygning = defaultBygning.withEgenregistrertData(listOf(laterRegistrering, defaultEgenregistrering))
+
+        assertThat(aggregatedBygning.bruksareal?.data).isEqualTo(150.0)
+    }
+}


### PR DESCRIPTION
* Endrer litt på strukturen for databaselagringen for å rydde opp i domeneobjektet `Egenregistrering`
* Sender EgenregService inn til BygningService fremfor EgenregRepo
* Lager funksjoner for å aggregere en liste med egenregistreringer til å fylle sist registrerte felt for bruksenhet og bygning

Jeg er ikke helt sikker på om bruksenhetaggregeringen trenger å være så "smart" som den er med filtrering og å sette opp et pair, sånn som jeg har kommentert.

NB: Hvis man nå registrerer på liste-registreringene (Oppvarming og Energikilder), så vil _hele_ registreringen få nytt registreringstidspunkt, det går ikke individuelt per felt