### PR TITLE
TB-66 Fjerne tidligere registrert felt

### DIFF
--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Bygning.kt
@@ -24,10 +24,10 @@ data class Bygning(
 }
 
 data class RegisterMetadata(val registreringstidspunkt: Instant)
-data class Bruksareal(val data: Double, val metadata: RegisterMetadata)
-data class Byggeaar(val data: Int, val metadata: RegisterMetadata)
-data class Vannforsyning(val data: VannforsyningKode, val metadata: RegisterMetadata)
-data class Avlop(val data: AvlopKode, val metadata: RegisterMetadata)
+data class Bruksareal(val data: Double?, val metadata: RegisterMetadata)
+data class Byggeaar(val data: Int?, val metadata: RegisterMetadata)
+data class Vannforsyning(val data: VannforsyningKode?, val metadata: RegisterMetadata)
+data class Avlop(val data: AvlopKode?, val metadata: RegisterMetadata)
 data class Energikilde(val data: EnergikildeKode, val metadata: RegisterMetadata)
 data class Oppvarming(val data: OppvarmingKode, val metadata: RegisterMetadata)
 

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensions.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/BygningExtensions.kt
@@ -78,7 +78,7 @@ fun Bruksenhet.withEgenregistrertData(egenregistreringer: List<Egenregistrering>
             },
             energikilder = bruksenhetAggregate.energikilder.takeIf { it.isNotEmpty() }
                 ?: egenregistrering.second.energikildeRegistrering?.let {
-                    it.energikilder.map { registrertKilde ->
+                    it.energikilder?.map { registrertKilde ->
                         Energikilde(
                             data = registrertKilde,
                             metadata = RegisterMetadata(
@@ -89,7 +89,7 @@ fun Bruksenhet.withEgenregistrertData(egenregistreringer: List<Egenregistrering>
                 } ?: emptyList(),
             oppvarminger = bruksenhetAggregate.oppvarminger.takeIf { it.isNotEmpty() }
                 ?: egenregistrering.second.oppvarmingRegistrering?.let {
-                    it.oppvarminger.map { registrertOppvarming ->
+                    it.oppvarminger?.map { registrertOppvarming ->
                         Oppvarming(
                             data = registrertOppvarming,
                             metadata = RegisterMetadata(

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Egenregistrering.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/Egenregistrering.kt
@@ -10,32 +10,32 @@ import java.util.*
 
 @Serializable
 data class ByggeaarRegistrering(
-    val byggeaar: Int,
+    val byggeaar: Int?,
 )
 
 @Serializable
 data class BruksarealRegistrering(
-    val bruksareal: Double,
+    val bruksareal: Double?,
 )
 
 @Serializable
 data class VannforsyningRegistrering(
-    val vannforsyning: VannforsyningKode,
+    val vannforsyning: VannforsyningKode?,
 )
 
 @Serializable
 data class AvlopRegistrering(
-    val avlop: AvlopKode,
+    val avlop: AvlopKode?,
 )
 
 @Serializable
 data class EnergikildeRegistrering(
-    val energikilder: List<EnergikildeKode>,
+    val energikilder: List<EnergikildeKode>?,
 )
 
 @Serializable
 data class OppvarmingRegistrering(
-    val oppvarminger: List<OppvarmingKode>,
+    val oppvarminger: List<OppvarmingKode>?,
 )
 
 

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/HTTP.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/HTTP.kt
@@ -20,7 +20,7 @@ fun Application.configureHTTP() {
             Json {
                 serializersModule = KompendiumSerializersModule.module
                 encodeDefaults = true
-                explicitNulls = false
+//                explicitNulls = false
             },
         )
         removeIgnoredType<String>()

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/dto/response/BygningResponse.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/dto/response/BygningResponse.kt
@@ -31,22 +31,22 @@ data class BygningResponse(
 data class RegisterMetadataResponse(@Serializable(with = InstantSerializer::class) val registreringstidspunkt: Instant)
 
 @Serializable
-data class ByggeaarResponse(val data: Int, val metadata: RegisterMetadataResponse)
+data class ByggeaarResponse(val data: Int?, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class BruksarealResponse(val data: Double, val metadata: RegisterMetadataResponse)
+data class BruksarealResponse(val data: Double?, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class VannforsyningKodeResponse(val data: VannforsyningKode, val metadata: RegisterMetadataResponse)
+data class VannforsyningKodeResponse(val data: VannforsyningKode?, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class AvlopKodeResponse(val data: AvlopKode, val metadata: RegisterMetadataResponse)
+data class AvlopKodeResponse(val data: AvlopKode?, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class EnergikildeResponse(val data: EnergikildeKode, val metadata: RegisterMetadataResponse)
+data class EnergikildeResponse(val data: EnergikildeKode?, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class OppvarmingResponse(val data: OppvarmingKode, val metadata: RegisterMetadataResponse)
+data class OppvarmingResponse(val data: OppvarmingKode?, val metadata: RegisterMetadataResponse)
 
 @Serializable
 data class BruksenhetResponse(


### PR DESCRIPTION
Ved å sende inn null til APIet på verdien til feltet så registrerer du en "sletting". Det vil si at f. eks ved innsending av:

`bruksarealRegistrering.bruksareal = null` så vil du få svar `bruksareal.egenregistrert.bruksareal = null`, men med registreringstidspunktet til null verdien. Det er altså forskjell på en spesifikt registrert null og en verdi som aldri har vært der. Om det er dette som skal bety sletting i fremtiden spørs nok, men det er hvert fall en start for egenregistrering å kunne slette tidligere innsendte verdier.

NB: Dette er ikke løst for liste-registreringer, her må vi gjøre noe glupere.