### PR TITLE
TH-58: Juster litt på testene

### DIFF
--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningBuilder.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningBuilder.kt
@@ -1,5 +1,7 @@
 package no.kartverket.matrikkel.bygning.matrikkelapi.builders
 
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelAvlopKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelVannforsyningKode
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BruksenhetId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BruksenhetIdList
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bygning
@@ -34,6 +36,10 @@ fun bygning(scope: Bygning.() -> Unit): Bygning = Bygning()
         if (bruksenhetIds == null) bruksenhetIds = BruksenhetIdList()
         if (energikildeKodeIds == null) energikildeKodeIds = EnergikildeKodeIdList()
         if (oppvarmingsKodeIds == null) oppvarmingsKodeIds = OppvarmingsKodeIdList()
+
+        // Fyller inn standard kodeid hvis det ikke har blitt fylt inn noe annet
+        if(vannforsyningsKodeId == null) vannforsyningsKodeId = MatrikkelVannforsyningKode.IkkeOppgitt()
+        if (avlopsKodeId == null) avlopsKodeId = MatrikkelAvlopKode.IkkeOppgitt()
     }
 
 fun Bygning.bruksenhetIds(vararg bruksenhetIds: BruksenhetId) {

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClientTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClientTest.kt
@@ -53,7 +53,7 @@ import kotlin.test.Test
 
 class MatrikkelBygningClientTest {
     @Test
-    fun bygningUnummerertBruksenhetUtenEtasje() {
+    fun `mapping takler minimalt utfylt bygning`() {
         val mockStoreService = mockk<StoreService> {
             val bygningId = bygningId(1L)
             val bruksenhetId = bruksenhetId(2L)
@@ -61,9 +61,6 @@ class MatrikkelBygningClientTest {
                 id = bygningId
                 bygningsnummer = 1000L
                 oppdateringsdato = timestampUtc(2024, 9, 13)
-                vannforsyningsKodeId = MatrikkelVannforsyningKode.IkkeOppgitt()
-                avlopsKodeId = MatrikkelAvlopKode.IkkeOppgitt()
-                etasjedata.bruksarealTotalt = 250.0
                 bruksenhetIds(bruksenhetId)
             }
             every { getObjects(matchIds(bruksenhetId), any()) } returns matrikkelBubbleObjectList(
@@ -89,7 +86,8 @@ class MatrikkelBygningClientTest {
             prop(Bygning::bygningId).isEqualTo(1L)
             prop(Bygning::bygningsnummer).isEqualTo(1000L)
             prop(Bygning::bruksareal).erAutoritativIkkeEgenregistrert {
-                prop(Bruksareal::data).isEqualTo(250.0)
+                // TODO: Dette skal egentlig være "vet ikke", som kanskje ikke skal representeres slik
+                prop(Bruksareal::data).isEqualTo(0.0)
                 prop(Bruksareal::metadata).isMatrikkelfoertBygningstidspunkt()
             }
             prop(Bygning::avlop).isEmpty()
@@ -111,7 +109,8 @@ class MatrikkelBygningClientTest {
     }
 
     @Test
-    fun bygningEneboligMedEtasje() {
+    fun `mapping mapper alle felter i fullt utfylt bygning`() {
+        // Bygningen er ikke fullt utfylt for det som enda ikke blir brukt
         val mockStoreService = mockk<StoreService> {
             val bygningId = bygningId(1L)
             val bruksenhetId = bruksenhetId(2L)


### PR DESCRIPTION
Tanken her er at den ene testen sjekker at mappingen ikke forventer at felt som ikke trenger være fylt inn, må være fylt inn, mens den andre testen sjekker at alle feltene som kan mappes, blir mappet. Så blir det andre mer spissede tester for der spesifikke kombinasjoner skal mappes litt spesielt, som f.eks. byggeår. Men hvordan få dette til å fremgå av navnene?