### PR TITLE
TB-67 Legg til utledning av byggeår basert på bygningsstatushistorikk

### DIFF
--- a/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/EnumIds.kt
+++ b/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/EnumIds.kt
@@ -1,8 +1,9 @@
 @file:Suppress("unused")
 
-package no.kartverket.matrikkel.bygning.matrikkelapi.builders
+package no.kartverket.matrikkel.bygning.matrikkelapi
 
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.AvlopsKodeId
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.BygningsstatusKodeId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.EnergikildeKodeId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.EtasjeplanKodeId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.KjokkentilgangKodeId
@@ -67,4 +68,12 @@ enum class MatrikkelKjokkentilgangKode(private val idValue: Long) {
     Ukjent(4);
 
     operator fun invoke() = KjokkentilgangKodeId().apply { value = idValue }
+}
+
+enum class MatrikkelBygningsstatusKode(private val idValue: Long) {
+    MidlertidigBrukstillatelse(2),
+    FerdigAttest(3),
+    TattIBruk(4);
+
+    operator fun invoke() = BygningsstatusKodeId().apply { value = idValue }
 }

--- a/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/XmlDate.kt
+++ b/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/XmlDate.kt
@@ -2,7 +2,6 @@ package no.kartverket.matrikkel.bygning.matrikkelapi
 
 import java.time.Instant
 import java.time.LocalDate
-import java.util.Calendar
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.LocalDate as MatrikkelLocalDate
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.Timestamp as MatrikkelTimestamp
 
@@ -11,13 +10,10 @@ fun MatrikkelTimestamp.toInstant(): Instant {
     return calendar.toInstant()
 }
 
-// TODO: Jeg aner ikke om dette blir riktig
 fun MatrikkelLocalDate.toLocalDate(): LocalDate {
-    val calendar = date.toGregorianCalendar()
-
     return LocalDate.of(
-        calendar.get(Calendar.YEAR),
-        calendar.get(Calendar.MONTH),
-        calendar.get(Calendar.DAY_OF_MONTH)
+        date.year,
+        date.month,
+        date.day,
     )
 }

--- a/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/XmlDate.kt
+++ b/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/XmlDate.kt
@@ -10,6 +10,14 @@ fun MatrikkelTimestamp.toInstant(): Instant {
     return calendar.toInstant()
 }
 
+fun MatrikkelTimestamp.toLocalDate(): LocalDate {
+    return LocalDate.of(
+        timestamp.year,
+        timestamp.month,
+        timestamp.day,
+    )
+}
+
 fun MatrikkelLocalDate.toLocalDate(): LocalDate {
     return LocalDate.of(
         date.year,

--- a/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/XmlDate.kt
+++ b/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/XmlDate.kt
@@ -1,9 +1,23 @@
 package no.kartverket.matrikkel.bygning.matrikkelapi
 
 import java.time.Instant
+import java.time.LocalDate
+import java.util.Calendar
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.LocalDate as MatrikkelLocalDate
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.Timestamp as MatrikkelTimestamp
 
 fun MatrikkelTimestamp.toInstant(): Instant {
     val calendar = timestamp.toGregorianCalendar() // TODO: Må sjekke litt mer på hvor trygt dette er
     return calendar.toInstant()
+}
+
+// TODO: Jeg aner ikke om dette blir riktig
+fun MatrikkelLocalDate.toLocalDate(): LocalDate {
+    val calendar = date.toGregorianCalendar()
+
+    return LocalDate.of(
+        calendar.get(Calendar.YEAR),
+        calendar.get(Calendar.MONTH),
+        calendar.get(Calendar.DAY_OF_MONTH)
+    )
 }

--- a/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/id/EnumIds.kt
+++ b/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/id/EnumIds.kt
@@ -1,6 +1,6 @@
 @file:Suppress("unused")
 
-package no.kartverket.matrikkel.bygning.matrikkelapi
+package no.kartverket.matrikkel.bygning.matrikkelapi.id
 
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.AvlopsKodeId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.BygningsstatusKodeId

--- a/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/id/Ids.kt
+++ b/matrikkel-api/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/id/Ids.kt
@@ -1,4 +1,4 @@
-package no.kartverket.matrikkel.bygning.matrikkelapi
+package no.kartverket.matrikkel.bygning.matrikkelapi.id
 
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BruksenhetId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningId

--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BruksenhetBuilder.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BruksenhetBuilder.kt
@@ -1,6 +1,6 @@
 package no.kartverket.matrikkel.bygning.matrikkelapi.builders
 
-import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelKjokkentilgangKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelKjokkentilgangKode
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bruksenhet
 
 fun bruksenhet(scope: Bruksenhet.() -> Unit) = Bruksenhet()

--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BruksenhetBuilder.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BruksenhetBuilder.kt
@@ -1,5 +1,6 @@
 package no.kartverket.matrikkel.bygning.matrikkelapi.builders
 
+import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelKjokkentilgangKode
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bruksenhet
 
 fun bruksenhet(scope: Bruksenhet.() -> Unit) = Bruksenhet()

--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningBuilder.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningBuilder.kt
@@ -22,6 +22,11 @@ fun bygning(scope: Bygning.() -> Unit): Bygning = Bygning()
         etasjedata.bruttoarealTilBolig = 0.0
         etasjedata.bruttoarealTilAnnet = 0.0
         etasjedata.bruttoarealTotalt = 0.0
+        bygningsstatusHistorikker = bygningsstatusHistorikkList(
+            bygningsstatusHistorikk {
+                registrertDato = timestampUtc(2000, 1, 1)
+            }
+        )
     }
     .apply(scope)
     .apply {

--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningsstatusHistorikkBuilder.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningsstatusHistorikkBuilder.kt
@@ -1,0 +1,29 @@
+package no.kartverket.matrikkel.bygning.matrikkelapi.builders
+
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikk
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikkList
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.BygningsstatusKodeId
+
+fun bygningsstatusHistorikkList(vararg historikker: BygningsstatusHistorikk) = BygningsstatusHistorikkList().apply {
+    item.addAll(historikker)
+}
+
+fun bygningsstatusHistorikk(scope: BygningsstatusHistorikk.() -> Unit) = BygningsstatusHistorikk().apply(scope)
+
+fun BygningsstatusHistorikk.withRegistrertDato(year: Int, month: Int, dayOfMonth: Int): BygningsstatusHistorikk {
+    return apply {
+        registrertDato = timestampUtc(year, month, dayOfMonth)
+    }
+}
+
+fun BygningsstatusHistorikk.withDato(year: Int, month: Int, dayOfMonth: Int): BygningsstatusHistorikk {
+    return apply {
+        dato = localDateUtc(year, month, dayOfMonth)
+    }
+}
+
+fun BygningsstatusHistorikk.withBygningsstatusKodeId(kodeId: BygningsstatusKodeId): BygningsstatusHistorikk {
+    return apply {
+        bygningsstatusKodeId = kodeId
+    }
+}

--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningsstatusHistorikkBuilder.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningsstatusHistorikkBuilder.kt
@@ -10,6 +10,14 @@ fun bygningsstatusHistorikkList(vararg historikker: BygningsstatusHistorikk) = B
 
 fun bygningsstatusHistorikk(scope: BygningsstatusHistorikk.() -> Unit) = BygningsstatusHistorikk().apply(scope)
 
+fun BygningsstatusHistorikk.copy(): BygningsstatusHistorikk {
+    return bygningsstatusHistorikk {
+        bygningsstatusKodeId = this@copy.bygningsstatusKodeId
+        registrertDato = this@copy.registrertDato
+        dato = this@copy.dato
+    }
+}
+
 fun BygningsstatusHistorikk.withRegistrertDato(year: Int, month: Int, dayOfMonth: Int): BygningsstatusHistorikk {
     return apply {
         registrertDato = timestampUtc(year, month, dayOfMonth)

--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningsstatusHistorikkBuilder.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/BygningsstatusHistorikkBuilder.kt
@@ -2,36 +2,9 @@ package no.kartverket.matrikkel.bygning.matrikkelapi.builders
 
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikk
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikkList
-import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.BygningsstatusKodeId
 
 fun bygningsstatusHistorikkList(vararg historikker: BygningsstatusHistorikk) = BygningsstatusHistorikkList().apply {
     item.addAll(historikker)
 }
 
 fun bygningsstatusHistorikk(scope: BygningsstatusHistorikk.() -> Unit) = BygningsstatusHistorikk().apply(scope)
-
-fun BygningsstatusHistorikk.copy(): BygningsstatusHistorikk {
-    return bygningsstatusHistorikk {
-        bygningsstatusKodeId = this@copy.bygningsstatusKodeId
-        registrertDato = this@copy.registrertDato
-        dato = this@copy.dato
-    }
-}
-
-fun BygningsstatusHistorikk.withRegistrertDato(year: Int, month: Int, dayOfMonth: Int): BygningsstatusHistorikk {
-    return apply {
-        registrertDato = timestampUtc(year, month, dayOfMonth)
-    }
-}
-
-fun BygningsstatusHistorikk.withDato(year: Int, month: Int, dayOfMonth: Int): BygningsstatusHistorikk {
-    return apply {
-        dato = localDateUtc(year, month, dayOfMonth)
-    }
-}
-
-fun BygningsstatusHistorikk.withBygningsstatusKodeId(kodeId: BygningsstatusKodeId): BygningsstatusHistorikk {
-    return apply {
-        bygningsstatusKodeId = kodeId
-    }
-}

--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/DatoBuilders.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/DatoBuilders.kt
@@ -10,6 +10,10 @@ fun timestampUtc(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0
     this.timestamp = datatypeFactory.newXMLGregorianCalendar(year, month, day, hour, minute, second, 0, 0)
 }
 
-fun localDateUtc(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0, second: Int = 0) = LocalDate().apply {
-    this.date = datatypeFactory.newXMLGregorianCalendar(year, month, day, hour, minute, second, 0, 0)
+fun localDateUtc(year: Int, month: Int, day: Int) = LocalDate().apply {
+    this.date = datatypeFactory.newXMLGregorianCalendar().apply {
+        this.year = year
+        this.month = month
+        this.day = day
+    }
 }

--- a/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/DatoBuilders.kt
+++ b/matrikkel-api/src/testFixtures/kotlin/no/kartverket/matrikkel/bygning/matrikkelapi/builders/DatoBuilders.kt
@@ -1,5 +1,6 @@
 package no.kartverket.matrikkel.bygning.matrikkelapi.builders
 
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.LocalDate
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.Timestamp
 import javax.xml.datatype.DatatypeFactory
 
@@ -7,4 +8,8 @@ private val datatypeFactory by lazy { DatatypeFactory.newDefaultInstance() }
 
 fun timestampUtc(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0, second: Int = 0) = Timestamp().apply {
     this.timestamp = datatypeFactory.newXMLGregorianCalendar(year, month, day, hour, minute, second, 0, 0)
+}
+
+fun localDateUtc(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0, second: Int = 0) = LocalDate().apply {
+    this.date = datatypeFactory.newXMLGregorianCalendar(year, month, day, hour, minute, second, 0, 0)
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
@@ -24,7 +24,7 @@ internal fun deriveByggeaarForBygning(bygning: MatrikkelBygning): Int? {
 }
 
 private fun isAfterThresholdDate(bygningsstatus: BygningsstatusHistorikk): Boolean =
-    (bygningsstatus.registrertDato.toLocalDate() > EARLIEST_DATE_FOR_DERIVING_BYGGEAAR)
+    bygningsstatus.registrertDato.toLocalDate() > EARLIEST_DATE_FOR_DERIVING_BYGGEAAR
 
 private fun isCorrectBygningsstatusKode(bygningsstatusKodeId: BygningsstatusKodeId): Boolean =
     bygningsstatusKodeId.value == MatrikkelBygningsstatusKode.FerdigAttest().value || bygningsstatusKodeId.value == MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse().value

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
@@ -2,32 +2,31 @@ package no.kartverket.matrikkel.bygning.matrikkel.adapters
 
 import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelBygningsstatusKode
 import no.kartverket.matrikkel.bygning.matrikkelapi.toLocalDate
-import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.Timestamp
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikk
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.BygningsstatusKodeId
 import java.time.LocalDate
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bygning as MatrikkelBygning
 
+// TODO: Hvordan dokumentere hvor denne datoen kommer fra?
 private val EARLIEST_DATE_FOR_DERIVING_BYGGEAAR = LocalDate.of(2009, 4, 25)
 
 // TODO: Det vil være mulig å få byggeår hvor bygningsstatus er veldig langt tilbakedatert, og vi kan nok anta at disse er feil.
 // Må gå opp hva "smerteterskelen" for hva som regnes som en ikke-godkjent bygningsstatusdato er
 internal fun deriveByggeaarForBygning(bygning: MatrikkelBygning): Int? {
-    if (bygning.bygningsstatusHistorikker == null) return null
-
     return bygning.bygningsstatusHistorikker.item
-        .filter { isAfterThresholdDate(it.registrertDato) }
+        .filter { isAfterThresholdDate(it) }
         .filter { isCorrectBygningsstatusKode(it.bygningsstatusKodeId) }
-        .filter { isNotDeleted(it.slettetDato) }
+        .filter { isNotDeleted(it) }
         .minByOrNull { it.dato.toLocalDate() }
         ?.dato
         ?.toLocalDate()
         ?.year
 }
 
-private fun isNotDeleted(slettetDato: Timestamp?): Boolean = slettetDato == null
+private fun isAfterThresholdDate(bygningsstatus: BygningsstatusHistorikk): Boolean =
+    (bygningsstatus.registrertDato.toLocalDate() > EARLIEST_DATE_FOR_DERIVING_BYGGEAAR)
 
 private fun isCorrectBygningsstatusKode(bygningsstatusKodeId: BygningsstatusKodeId): Boolean =
     bygningsstatusKodeId == MatrikkelBygningsstatusKode.FerdigAttest() || bygningsstatusKodeId == MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
 
-private fun isAfterThresholdDate(registrertDato: Timestamp): Boolean =
-    (registrertDato.toLocalDate() > EARLIEST_DATE_FOR_DERIVING_BYGGEAAR)
+private fun isNotDeleted(bygningsstatus: BygningsstatusHistorikk): Boolean = bygningsstatus.slettetDato == null

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
@@ -1,13 +1,13 @@
 package no.kartverket.matrikkel.bygning.matrikkel.adapters
 
-import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelBygningsstatusKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelBygningsstatusKode
 import no.kartverket.matrikkel.bygning.matrikkelapi.toLocalDate
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.Timestamp
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.BygningsstatusKodeId
 import java.time.LocalDate
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bygning as MatrikkelBygning
 
-private val earliestDateForDerivingByggeaar = LocalDate.of(2009, 4, 25)
+private val EARLIEST_DATE_FOR_DERIVING_BYGGEAAR = LocalDate.of(2009, 4, 25)
 
 // TODO: Det vil være mulig å få byggeår hvor bygningsstatus er veldig langt tilbakedatert, og vi kan nok anta at disse er feil.
 // Må gå opp hva "smerteterskelen" for hva som regnes som en ikke-godkjent bygningsstatusdato er
@@ -30,4 +30,4 @@ private fun isCorrectBygningsstatusKode(bygningsstatusKodeId: BygningsstatusKode
     bygningsstatusKodeId == MatrikkelBygningsstatusKode.FerdigAttest() || bygningsstatusKodeId == MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
 
 private fun isAfterThresholdDate(registrertDato: Timestamp): Boolean =
-    (registrertDato.toLocalDate() > earliestDateForDerivingByggeaar)
+    (registrertDato.toLocalDate() > EARLIEST_DATE_FOR_DERIVING_BYGGEAAR)

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
@@ -27,6 +27,6 @@ private fun isAfterThresholdDate(bygningsstatus: BygningsstatusHistorikk): Boole
     (bygningsstatus.registrertDato.toLocalDate() > EARLIEST_DATE_FOR_DERIVING_BYGGEAAR)
 
 private fun isCorrectBygningsstatusKode(bygningsstatusKodeId: BygningsstatusKodeId): Boolean =
-    bygningsstatusKodeId == MatrikkelBygningsstatusKode.FerdigAttest() || bygningsstatusKodeId == MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
+    bygningsstatusKodeId.value == MatrikkelBygningsstatusKode.FerdigAttest().value || bygningsstatusKodeId.value == MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse().value
 
 private fun isNotDeleted(bygningsstatus: BygningsstatusHistorikk): Boolean = bygningsstatus.slettetDato == null

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
@@ -2,28 +2,30 @@ package no.kartverket.matrikkel.bygning.matrikkel.adapters
 
 import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelBygningsstatusKode
 import no.kartverket.matrikkel.bygning.matrikkelapi.toLocalDate
-import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikk
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.Timestamp
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.koder.BygningsstatusKodeId
 import java.time.LocalDate
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bygning as MatrikkelBygning
 
 private val earliestDateForDerivingByggeaar = LocalDate.of(2009, 4, 25)
 
-// TODO Hvilken dato fra bygningsstatus er det som faktisk regnes som riktig dato å sjekke mot?
+// TODO: Det vil være mulig å få byggeår hvor bygningsstatus er veldig langt tilbakedatert, og vi kan nok anta at disse er feil.
+// Må gå opp hva "smerteterskelen" for hva som regnes som en ikke-godkjent bygningsstatusdato er
 internal fun deriveByggeaarForBygning(bygning: MatrikkelBygning): Int? {
     return bygning.bygningsstatusHistorikker.item
-        .filter { isAfterThresholdDate(it) }
-        .filter { isCorrectBygningsstatusKode(it) }
-        .filter { isNotDeleted(it) }
+        .filter { isAfterThresholdDate(it.registrertDato) }
+        .filter { isCorrectBygningsstatusKode(it.bygningsstatusKodeId) }
+        .filter { isNotDeleted(it.slettetDato) }
         .minByOrNull { it.dato.toLocalDate() }
         ?.dato
         ?.toLocalDate()
         ?.year
 }
 
-private fun isNotDeleted(historikk: BygningsstatusHistorikk): Boolean = historikk.slettetDato == null
+private fun isNotDeleted(slettetDato: Timestamp?): Boolean = slettetDato == null
 
-private fun isCorrectBygningsstatusKode(historikk: BygningsstatusHistorikk): Boolean =
-    historikk.bygningsstatusKodeId == MatrikkelBygningsstatusKode.FerdigAttest() || historikk.bygningsstatusKodeId == MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
+private fun isCorrectBygningsstatusKode(bygningsstatusKodeId: BygningsstatusKodeId): Boolean =
+    bygningsstatusKodeId == MatrikkelBygningsstatusKode.FerdigAttest() || bygningsstatusKodeId == MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
 
-private fun isAfterThresholdDate(historikk: BygningsstatusHistorikk): Boolean =
-    (historikk.dato.toLocalDate() > earliestDateForDerivingByggeaar)
+private fun isAfterThresholdDate(registrertDato: Timestamp): Boolean =
+    (registrertDato.toLocalDate() > earliestDateForDerivingByggeaar)

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
@@ -12,6 +12,8 @@ private val earliestDateForDerivingByggeaar = LocalDate.of(2009, 4, 25)
 // TODO: Det vil være mulig å få byggeår hvor bygningsstatus er veldig langt tilbakedatert, og vi kan nok anta at disse er feil.
 // Må gå opp hva "smerteterskelen" for hva som regnes som en ikke-godkjent bygningsstatusdato er
 internal fun deriveByggeaarForBygning(bygning: MatrikkelBygning): Int? {
+    if (bygning.bygningsstatusHistorikker == null) return null
+
     return bygning.bygningsstatusHistorikker.item
         .filter { isAfterThresholdDate(it.registrertDato) }
         .filter { isCorrectBygningsstatusKode(it.bygningsstatusKodeId) }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriver.kt
@@ -1,0 +1,29 @@
+package no.kartverket.matrikkel.bygning.matrikkel.adapters
+
+import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelBygningsstatusKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.toLocalDate
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikk
+import java.time.LocalDate
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bygning as MatrikkelBygning
+
+private val earliestDateForDerivingByggeaar = LocalDate.of(2009, 4, 25)
+
+// TODO Hvilken dato fra bygningsstatus er det som faktisk regnes som riktig dato å sjekke mot?
+internal fun deriveByggeaarForBygning(bygning: MatrikkelBygning): Int? {
+    return bygning.bygningsstatusHistorikker.item
+        .filter { isAfterThresholdDate(it) }
+        .filter { isCorrectBygningsstatusKode(it) }
+        .filter { isNotDeleted(it) }
+        .minByOrNull { it.dato.toLocalDate() }
+        ?.dato
+        ?.toLocalDate()
+        ?.year
+}
+
+private fun isNotDeleted(historikk: BygningsstatusHistorikk): Boolean = historikk.slettetDato == null
+
+private fun isCorrectBygningsstatusKode(historikk: BygningsstatusHistorikk): Boolean =
+    historikk.bygningsstatusKodeId == MatrikkelBygningsstatusKode.FerdigAttest() || historikk.bygningsstatusKodeId == MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
+
+private fun isAfterThresholdDate(historikk: BygningsstatusHistorikk): Boolean =
+    (historikk.dato.toLocalDate() > earliestDateForDerivingByggeaar)

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClient.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClient.kt
@@ -2,9 +2,9 @@ package no.kartverket.matrikkel.bygning.matrikkel.adapters
 
 import no.kartverket.matrikkel.bygning.matrikkel.BygningClient
 import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelApi
-import no.kartverket.matrikkel.bygning.matrikkelapi.id.bygningId
 import no.kartverket.matrikkel.bygning.matrikkelapi.getBruksenheter
 import no.kartverket.matrikkel.bygning.matrikkelapi.getBygning
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.bygningId
 import no.kartverket.matrikkel.bygning.matrikkelapi.toInstant
 import no.kartverket.matrikkel.bygning.models.Avlop
 import no.kartverket.matrikkel.bygning.models.Bruksareal
@@ -126,6 +126,4 @@ internal class MatrikkelBygningClient(
             return null
         }
     }
-
-
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClient.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClient.kt
@@ -6,7 +6,6 @@ import no.kartverket.matrikkel.bygning.matrikkelapi.bygningId
 import no.kartverket.matrikkel.bygning.matrikkelapi.getBruksenheter
 import no.kartverket.matrikkel.bygning.matrikkelapi.getBygning
 import no.kartverket.matrikkel.bygning.matrikkelapi.toInstant
-import no.kartverket.matrikkel.bygning.matrikkelapi.toLocalDate
 import no.kartverket.matrikkel.bygning.models.Avlop
 import no.kartverket.matrikkel.bygning.models.Bruksareal
 import no.kartverket.matrikkel.bygning.models.Bruksenhet
@@ -21,8 +20,6 @@ import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.service.store.ServiceException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.LocalDate
-import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.Bygning as MatrikkelBygning
 
 // TODO Håndtering av at matrikkel servicene thrower på visse vanlige HTTP koder, ikke bare full try/catch
 internal class MatrikkelBygningClient(
@@ -45,10 +42,12 @@ internal class MatrikkelBygningClient(
                 bygningId = bygning.id.value,
                 bygningsnummer = bygning.bygningsnummer,
                 byggeaar = Multikilde(
-                    autoritativ = Byggeaar(
-                        data = calculateByggeaarForBygning(bygning),
-                        metadata = bygningsmetadata,
-                    ),
+                    autoritativ = deriveByggeaarForBygning(bygning)?.let {
+                        Byggeaar(
+                            data = it,
+                            metadata = bygningsmetadata,
+                        )
+                    },
                 ),
                 // TODO: Hvordan innse at arealet er ukjent og hvordan håndtere dette
                 bruksareal = Multikilde(
@@ -128,24 +127,5 @@ internal class MatrikkelBygningClient(
         }
     }
 
-    // TODO Hvilken dato fra bygningsstatus er det som faktisk regnes som riktig dato å sjekke mot?
-    private fun calculateByggeaarForBygning(bygning: MatrikkelBygning): Int {
-        val bygningsstatuserWithDerivableByggeaar = bygning.bygningsstatusHistorikker.item.filter {
-            // TODO Sjekke faktisk dato
-            val earliestDateForDerivingByggeaar = LocalDate.of(2013, 1, 1)
 
-            val isBygningsstatusDerivable = (it.dato.toLocalDate() >= earliestDateForDerivingByggeaar)
-
-            // TODO Hvilke verdier skal vi faktisk bruke her? Trenger vi å lage en mapper
-            val isCorrectBygningsstatusType = it.bygningsstatusKodeId.value == 0L || it.bygningsstatusKodeId.value == 1L
-
-            isCorrectBygningsstatusType && isBygningsstatusDerivable
-        }
-
-        // Nullability her?
-        if (bygningsstatuserWithDerivableByggeaar.isEmpty()) return -1
-
-        // TODO Hvis det er flere bygningsstatuser som er innafor for å derivere, hvilken skal vi egentlig bruke?
-        return bygningsstatuserWithDerivableByggeaar.sortedBy { it.dato.toLocalDate() }.first().dato.toLocalDate().year
-    }
 }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClient.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClient.kt
@@ -2,7 +2,7 @@ package no.kartverket.matrikkel.bygning.matrikkel.adapters
 
 import no.kartverket.matrikkel.bygning.matrikkel.BygningClient
 import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelApi
-import no.kartverket.matrikkel.bygning.matrikkelapi.bygningId
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.bygningId
 import no.kartverket.matrikkel.bygning.matrikkelapi.getBruksenheter
 import no.kartverket.matrikkel.bygning.matrikkelapi.getBygning
 import no.kartverket.matrikkel.bygning.matrikkelapi.toInstant

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
@@ -1,0 +1,72 @@
+package no.kartverket.matrikkel.bygning.matrikkel.adapters
+
+import assertk.assertThat
+import assertk.assertions.isNull
+import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelBygningsstatusKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygning
+import no.kartverket.matrikkel.bygning.matrikkelapi.builders.localDateUtc
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikk
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikkList
+import kotlin.test.Test
+
+class ByggeaarDeriverTest {
+    @Test
+    fun `bygning med riktig status som ikke er etter terskeldato skal ikke faa byggeaar`() {
+        val bygningsStatusHistorikkList = BygningsstatusHistorikkList()
+
+        bygningsStatusHistorikkList.item.add(
+            BygningsstatusHistorikk().apply {
+                bygningsstatusKodeId = MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
+                dato = localDateUtc(2009, 4, 25)
+            },
+        )
+
+        val bygning = bygning {
+            bygningsstatusHistorikker = bygningsStatusHistorikkList
+        }
+
+        val derivedByggeaar = deriveByggeaarForBygning(bygning)
+
+        assertThat(derivedByggeaar).isNull()
+    }
+
+    @Test
+    fun `bygning med riktig status som er etter terskeldato skal faa byggeaar`() {
+        val bygningsStatusHistorikkList = BygningsstatusHistorikkList()
+
+        bygningsStatusHistorikkList.item.add(
+            BygningsstatusHistorikk().apply {
+                bygningsstatusKodeId = MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
+                dato = localDateUtc(2009, 4, 26)
+            },
+        )
+
+        val bygning = bygning {
+            bygningsstatusHistorikker = bygningsStatusHistorikkList
+        }
+
+        val derivedByggeaar = deriveByggeaarForBygning(bygning)
+
+        assertThat(derivedByggeaar).equals(2009)
+    }
+
+    @Test
+    fun `bygning med feil status som er etter terskeldato skal ikke faa byggeaar`() {
+        val bygningsStatusHistorikkList = BygningsstatusHistorikkList()
+
+        bygningsStatusHistorikkList.item.add(
+            BygningsstatusHistorikk().apply {
+                bygningsstatusKodeId = MatrikkelBygningsstatusKode.TattIBruk()
+                dato = localDateUtc(2009, 4, 26)
+            },
+        )
+
+        val bygning = bygning {
+            bygningsstatusHistorikker = bygningsStatusHistorikkList
+        }
+
+        val derivedByggeaar = deriveByggeaarForBygning(bygning)
+
+        assertThat(derivedByggeaar).isNull()
+    }
+}

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
@@ -1,10 +1,12 @@
 package no.kartverket.matrikkel.bygning.matrikkel.adapters
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygning
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygningsstatusHistorikk
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygningsstatusHistorikkList
+import no.kartverket.matrikkel.bygning.matrikkelapi.builders.copy
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.localDateUtc
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.timestampUtc
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.withBygningsstatusKodeId
@@ -29,7 +31,7 @@ class ByggeaarDeriverTest {
 
         val derivedByggeaar = deriveByggeaarForBygning(bygning)
 
-        assertThat(derivedByggeaar).equals(2009)
+        assertThat(derivedByggeaar).isEqualTo(2009)
     }
 
     @Test
@@ -42,7 +44,7 @@ class ByggeaarDeriverTest {
 
         val derivedByggeaar = deriveByggeaarForBygning(bygning)
 
-        assertThat(derivedByggeaar).equals(2009)
+        assertThat(derivedByggeaar).isEqualTo(2009)
     }
 
     @Test
@@ -73,12 +75,12 @@ class ByggeaarDeriverTest {
         val bygning = bygning {
             bygningsstatusHistorikker = bygningsstatusHistorikkList(
                 derivableBygningsstatusHistorikk,
-                derivableBygningsstatusHistorikk.withRegistrertDato(2010, 4, 26).withDato(2010, 4, 26),
+                derivableBygningsstatusHistorikk.copy().withRegistrertDato(2010, 4, 26).withDato(2010, 4, 26),
             )
         }
 
         val derivedByggeaar = deriveByggeaarForBygning(bygning)
 
-        assertThat(derivedByggeaar).equals(2009)
+        assertThat(derivedByggeaar).isEqualTo(2009)
     }
 }

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
@@ -6,12 +6,8 @@ import assertk.assertions.isNull
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygning
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygningsstatusHistorikk
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygningsstatusHistorikkList
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.copy
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.localDateUtc
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.timestampUtc
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.withBygningsstatusKodeId
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.withDato
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.withRegistrertDato
 import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelBygningsstatusKode
 import kotlin.test.Test
 
@@ -38,7 +34,11 @@ class ByggeaarDeriverTest {
     fun `bygning med ferdigattest som er etter terskeldato skal faa byggeaar`() {
         val bygning = bygning {
             bygningsstatusHistorikker = bygningsstatusHistorikkList(
-                derivableBygningsstatusHistorikk.withBygningsstatusKodeId(MatrikkelBygningsstatusKode.FerdigAttest()),
+                bygningsstatusHistorikk {
+                    bygningsstatusKodeId = MatrikkelBygningsstatusKode.FerdigAttest()
+                    registrertDato = timestampUtc(2009, 4, 26)
+                    dato = localDateUtc(2009, 4, 24)
+                }
             )
         }
 
@@ -50,7 +50,13 @@ class ByggeaarDeriverTest {
     @Test
     fun `bygning med riktig status som ikke er etter terskeldato skal ikke faa byggeaar`() {
         val bygning = bygning {
-            bygningsstatusHistorikker = bygningsstatusHistorikkList(derivableBygningsstatusHistorikk.withRegistrertDato(2009, 4, 25))
+            bygningsstatusHistorikker = bygningsstatusHistorikkList(
+                bygningsstatusHistorikk {
+                    bygningsstatusKodeId = MatrikkelBygningsstatusKode.FerdigAttest()
+                    registrertDato = timestampUtc(2009, 4, 25)
+                    dato = localDateUtc(2009, 4, 24)
+                }
+            )
         }
 
         val derivedByggeaar = deriveByggeaarForBygning(bygning)
@@ -61,8 +67,13 @@ class ByggeaarDeriverTest {
     @Test
     fun `bygning med feil status som er etter terskeldato skal ikke faa byggeaar`() {
         val bygning = bygning {
-            bygningsstatusHistorikker =
-                bygningsstatusHistorikkList(derivableBygningsstatusHistorikk.withBygningsstatusKodeId(MatrikkelBygningsstatusKode.TattIBruk()))
+            bygningsstatusHistorikker = bygningsstatusHistorikkList(
+                bygningsstatusHistorikk {
+                    bygningsstatusKodeId = MatrikkelBygningsstatusKode.TattIBruk()
+                    registrertDato = timestampUtc(2009, 4, 26)
+                    dato = localDateUtc(2009, 4, 24)
+                }
+            )
         }
 
         val derivedByggeaar = deriveByggeaarForBygning(bygning)
@@ -75,7 +86,11 @@ class ByggeaarDeriverTest {
         val bygning = bygning {
             bygningsstatusHistorikker = bygningsstatusHistorikkList(
                 derivableBygningsstatusHistorikk,
-                derivableBygningsstatusHistorikk.copy().withRegistrertDato(2010, 4, 26).withDato(2010, 4, 26),
+                bygningsstatusHistorikk {
+                    bygningsstatusKodeId = MatrikkelBygningsstatusKode.TattIBruk()
+                    registrertDato = timestampUtc(2010, 4, 26)
+                    dato = localDateUtc(2010, 4, 24)
+                }
             )
         }
 

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
@@ -11,7 +11,6 @@ import no.kartverket.matrikkel.bygning.matrikkelapi.builders.timestampUtc
 import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelBygningsstatusKode
 import kotlin.test.Test
 
-
 class ByggeaarDeriverTest {
     val derivableBygningsstatusHistorikk = bygningsstatusHistorikk {
         bygningsstatusKodeId = MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
@@ -82,7 +81,7 @@ class ByggeaarDeriverTest {
     }
 
     @Test
-    fun `bygning med flere gyldige statuser skal bruke eldst status for byggeår`() {
+    fun `bygning med flere gyldige statuser skal bruke eldste status for byggeaar`() {
         val bygning = bygning {
             bygningsstatusHistorikker = bygningsstatusHistorikkList(
                 derivableBygningsstatusHistorikk,

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/ByggeaarDeriverTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isNull
 import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelBygningsstatusKode
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygning
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.localDateUtc
+import no.kartverket.matrikkel.bygning.matrikkelapi.builders.timestampUtc
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikk
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningsstatusHistorikkList
 import kotlin.test.Test
@@ -17,7 +18,8 @@ class ByggeaarDeriverTest {
         bygningsStatusHistorikkList.item.add(
             BygningsstatusHistorikk().apply {
                 bygningsstatusKodeId = MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
-                dato = localDateUtc(2009, 4, 25)
+                registrertDato = timestampUtc(2009, 4, 25)
+                dato = localDateUtc(2009, 4, 23)
             },
         )
 
@@ -37,7 +39,8 @@ class ByggeaarDeriverTest {
         bygningsStatusHistorikkList.item.add(
             BygningsstatusHistorikk().apply {
                 bygningsstatusKodeId = MatrikkelBygningsstatusKode.MidlertidigBrukstillatelse()
-                dato = localDateUtc(2009, 4, 26)
+                registrertDato = timestampUtc(2009, 4, 26)
+                dato = localDateUtc(2009, 4, 24)
             },
         )
 
@@ -57,7 +60,8 @@ class ByggeaarDeriverTest {
         bygningsStatusHistorikkList.item.add(
             BygningsstatusHistorikk().apply {
                 bygningsstatusKodeId = MatrikkelBygningsstatusKode.TattIBruk()
-                dato = localDateUtc(2009, 4, 26)
+                registrertDato = timestampUtc(2009, 4, 26)
+                dato = localDateUtc(2009, 4, 24)
             },
         )
 

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClientTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClientTest.kt
@@ -14,12 +14,12 @@ import io.mockk.checkUnnecessaryStub
 import io.mockk.every
 import io.mockk.mockk
 import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelApi
-import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelAvlopKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelEnergikildeKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelEtasjeplanKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelOppvarmingKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelVannforsyningKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.bruksenhetId
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelAvlopKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelEnergikildeKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelEtasjeplanKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelOppvarmingKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.MatrikkelVannforsyningKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.bruksenhetId
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bruksenhet
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bruksenhetIds
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygning
@@ -29,7 +29,7 @@ import no.kartverket.matrikkel.bygning.matrikkelapi.builders.etasjer
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.matrikkelBubbleObjectList
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.oppvarmingsKodeIdList
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.timestampUtc
-import no.kartverket.matrikkel.bygning.matrikkelapi.bygningId
+import no.kartverket.matrikkel.bygning.matrikkelapi.id.bygningId
 import no.kartverket.matrikkel.bygning.matrikkelapi.matchers.matchId
 import no.kartverket.matrikkel.bygning.matrikkelapi.matchers.matchIds
 import no.kartverket.matrikkel.bygning.models.Avlop

--- a/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClientTest.kt
+++ b/src/test/kotlin/no/kartverket/matrikkel/bygning/matrikkel/adapters/MatrikkelBygningClientTest.kt
@@ -14,12 +14,12 @@ import io.mockk.checkUnnecessaryStub
 import io.mockk.every
 import io.mockk.mockk
 import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelApi
+import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelAvlopKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelEnergikildeKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelEtasjeplanKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelOppvarmingKode
+import no.kartverket.matrikkel.bygning.matrikkelapi.MatrikkelVannforsyningKode
 import no.kartverket.matrikkel.bygning.matrikkelapi.bruksenhetId
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.MatrikkelAvlopKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.MatrikkelEnergikildeKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.MatrikkelEtasjeplanKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.MatrikkelOppvarmingKode
-import no.kartverket.matrikkel.bygning.matrikkelapi.builders.MatrikkelVannforsyningKode
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bruksenhet
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bruksenhetIds
 import no.kartverket.matrikkel.bygning.matrikkelapi.builders.bygning


### PR DESCRIPTION
Legger til utledning av byggeår.

Etter diskusjon med Cato kom vi fram til at vi sjekker _registreringsdato_ for å vurdere hvorvidt det skal være mulig å utlede byggeåret, men bruker _statusdato_ for å faktisk utlede byggeåret.

Det vil likevel kunne dukke opp en situasjon, slik som @kvstrant har sendt tidligere, hvor registreringsdato er satt til å være etter godkjent dato, men statusen er satt til å være i år 320 f. eks. I disse tilfellene er det jo åpenbart noe feil, men vi må nok bare gå opp hva som regnes som en akseptabel terskel i forskjell mellom registreringsdato og statusdato.