### PR TITLE
TB-71 Tillat syntetiske fødselsnummere, og bruk InternalServerError som default StatusPage

### DIFF
--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/models/RegistreringAktoer.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/models/RegistreringAktoer.kt
@@ -7,6 +7,9 @@ sealed class RegistreringAktoer {
 
     data class Foedselsnummer(override val value: String) : RegistreringAktoer() {
         init {
+            // TODO Dette burde ikke være lov når vi er i prod, da må vi sjekke miljøet vi er i
+            FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true
+
             if (!FodselsnummerValidator.isValid(value)) {
                 throw IllegalArgumentException("Fødselsnummer er ikke gyldig")
             }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/StatusPages.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/StatusPages.kt
@@ -52,39 +52,16 @@ fun Application.configureStatusPages() {
                 is IllegalArgumentException -> {
                     logger.warn("Illegal argument exception", exception)
 
-                    when (exception) {
-                        is NumberFormatException -> call.respond(
-                            HttpStatusCode.BadRequest,
-                            ErrorResponse.BadRequestError(
-                                details = listOf(
-                                    ErrorDetail(
-                                        detail = "Et parameter/argument i requesten din kunne ikke formateres. Sjekk at alle IDer har riktig type.",
-                                    ),
-                                ),
-                            ),
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        ErrorResponse.BadRequestError(
+                            details = listOf(
+                                ErrorDetail(
+                                    detail = exception.message ?: "Et eller flere felter i requesten var ugyldig"
+                                )
+                            )
                         )
-
-                        else -> {
-                            val message = exception.message
-                            if (message != null && message.contains("Fødselsnummer er ikke gyldig")) {
-                                call.respond(
-                                    HttpStatusCode.BadRequest,
-                                    ErrorResponse.BadRequestError(
-                                        details = listOf(
-                                            ErrorDetail(
-                                                detail = "Et av fødselsnummerene i requesten din kunne ikke valideres",
-                                            ),
-                                        ),
-                                    ),
-                                )
-                            } else {
-                                call.respond(
-                                    HttpStatusCode.InternalServerError,
-                                    ErrorResponse.InternalServerError(),
-                                )
-                            }
-                        }
-                    }
+                    )
                 }
 
                 else -> {

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/StatusPages.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/StatusPages.kt
@@ -16,60 +16,84 @@ private val logger: Logger = LoggerFactory.getLogger(object {}::class.java)
 fun Application.configureStatusPages() {
     install(StatusPages) {
         exception<Throwable> { call, exception ->
-            logger.error("Noe gikk galt", exception)
-            call.respond(
-                HttpStatusCode.InternalServerError,
-                ErrorResponse.InternalServerError(),
-            )
-        }
+            when (exception) {
+                is BadRequestException -> {
+                    logger.warn("Bad request exception", exception)
+                    when (val cause = exception.cause) {
+                        is JsonConvertException -> {
+                            call.respond(
+                                HttpStatusCode.BadRequest,
+                                ErrorResponse.BadRequestError(
+                                    details = listOf(
+                                        ErrorDetail(
+                                            detail = cause.message ?: "Ukjent feil etter serialisering av request objekt",
+                                        ),
+                                    ),
+                                ),
+                            )
+                        }
 
-        exception<BadRequestException> { call, exception ->
-            logger.warn("Bad request exception", exception)
+                        else -> {
+                            call.respond(
+                                HttpStatusCode.BadRequest,
+                                ErrorResponse.BadRequestError(
+                                    details = listOf(
+                                        ErrorDetail(
+                                            detail = exception.message
+                                                ?: "Ukjent feil med request gjør at server ikke kan håndtere forespørselen",
+                                        ),
+                                    ),
+                                ),
+                            )
+                        }
+                    }
+                }
 
-            when (val cause = exception.cause) {
-                is JsonConvertException -> {
-                    call.respond(
-                        HttpStatusCode.BadRequest,
-                        ErrorResponse.BadRequestError(
-                            details = listOf(
-                                ErrorDetail(
-                                    detail = cause.message ?: "Ukjent feil etter serialisering av request objekt",
+                is IllegalArgumentException -> {
+                    logger.warn("Illegal argument exception", exception)
+
+                    when (exception) {
+                        is NumberFormatException -> call.respond(
+                            HttpStatusCode.BadRequest,
+                            ErrorResponse.BadRequestError(
+                                details = listOf(
+                                    ErrorDetail(
+                                        detail = "Et parameter/argument i requesten din kunne ikke formateres. Sjekk at alle IDer har riktig type.",
+                                    ),
                                 ),
                             ),
-                        ),
-                    )
+                        )
+
+                        else -> {
+                            val message = exception.message
+                            if (message != null && message.contains("Fødselsnummer ereoirgj ikke gyldig")) {
+                                call.respond(
+                                    HttpStatusCode.BadRequest,
+                                    ErrorResponse.BadRequestError(
+                                        details = listOf(
+                                            ErrorDetail(
+                                                detail = "Et av fødselsnummerene i requesten din kunne ikke valideres",
+                                            ),
+                                        ),
+                                    ),
+                                )
+                            } else {
+                                call.respond(
+                                    HttpStatusCode.InternalServerError,
+                                    ErrorResponse.InternalServerError(),
+                                )
+                            }
+                        }
+                    }
                 }
 
                 else -> {
+                    logger.error("Uhåndtert exception kastet", exception)
                     call.respond(
-                        HttpStatusCode.BadRequest,
-                        ErrorResponse.BadRequestError(
-                            details = listOf(
-                                ErrorDetail(
-                                    detail = exception.message
-                                        ?: "Ukjent feil med request gjør at server ikke kan håndtere forespørselen",
-                                ),
-                            ),
-                        ),
+                        HttpStatusCode.InternalServerError,
+                        ErrorResponse.InternalServerError(),
                     )
                 }
-            }
-        }
-
-        exception<IllegalArgumentException> { call, exception ->
-            logger.warn("Illegal argument exception", exception)
-
-            when (exception) {
-                is NumberFormatException -> call.respond(
-                    HttpStatusCode.BadRequest,
-                    ErrorResponse.BadRequestError(
-                        details = listOf(
-                            ErrorDetail(
-                                detail = "Et parameter/argument i requesten din kunne ikke formateres. Sjekk at alle IDer har riktig type.",
-                            ),
-                        ),
-                    ),
-                )
             }
         }
     }

--- a/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/StatusPages.kt
+++ b/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/StatusPages.kt
@@ -66,7 +66,7 @@ fun Application.configureStatusPages() {
 
                         else -> {
                             val message = exception.message
-                            if (message != null && message.contains("Fødselsnummer ereoirgj ikke gyldig")) {
+                            if (message != null && message.contains("Fødselsnummer er ikke gyldig")) {
                                 call.respond(
                                     HttpStatusCode.BadRequest,
                                     ErrorResponse.BadRequestError(


### PR DESCRIPTION
Testmiljøer inneholder syntetiske fødselsnummere, ikke faktiske fødselsnummere, så vi må tillate disse.

Feilen dukket opp som en uhåndtert `InternalServerError`, siden det var en del av `IllegalArgumentException`, men ble ikke spesifikt håndtert.

Har lagt inn det som en default, samt også en ytterligere default for `IllegalArgumentException`

Jeg er _ikke_ fan av chainingen her, men det virket å være greieste måte å ha fallbacks til InternalServerError. Må gå opp beste måte å håndtere de exceptionene som kan dukke opp. Mulig vi bare burde senke detaljeringsnivået i StatusPages?