### PR TITLE
chore: replace com.github.johnrengelman.shadow with com.gradleup.shadow

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ logstashVersion = "8.0"
 prometheusVersion = "1.14.1"
 flywayVersion = "10.22.0"
 postgresVersion = "42.7.4"
-shadowVersion = "8.1.1"
+shadowVersion = "8.3.5"
 jaxwsVersion = "4.0.3"
 hikariVersion = "6.2.1"
 testcontainersVersion = "1.20.4"
@@ -58,4 +58,4 @@ kotlin-jvm = { id = "jvm", version.ref = "kotlinVersion" }
 kotlin-serialization = { id = "plugin.serialization", version.ref = "kotlinVersion" }
 
 ktor = { id = "io.ktor.plugin", version.ref = "ktorVersion" }
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadowVersion" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadowVersion" }


### PR DESCRIPTION
com.github.johnrengelman.shadow plugin has changed the core maintainer and has new coordinates: https://plugins.gradle.org/plugin/com.gradleup.shadow

for more info se: https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow