### PR TITLE
Autentisering mot maskinporten

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ assertkVersion = "0.28.1"
 norwegianCommonsVersion = "0.16.0"
 kotlinResultVersion = "2.0.0"
 ktorSwaggerUIVersion = "4.0.0"
+mockOauth2Server = "2.1.10"
 
 [libraries]
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core-jvm", version.ref = "ktorVersion" }
@@ -47,6 +48,7 @@ jaxws-tools = { group = "com.sun.xml.ws", name = "jaxws-tools", version.ref = "j
 testcontainers-postgresql = { group = "org.testcontainers", name = "postgresql", version.ref = "testcontainersVersion" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockkVersion" }
 mockk-dsl = { group = "io.mockk", name = "mockk-dsl", version.ref = "mockkVersion" }
+mock-oauth2-server = { group = "no.nav.security", name = "mock-oauth2-server", version.ref = "mockOauth2Server" }
 assertk = { group = "com.willowtreeapps.assertk", name = "assertk", version.ref = "assertkVersion" }
 
 norwegian-commons = { group = "no.bekk.bekkopen", name = "nocommons", version.ref = "norwegianCommonsVersion" }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -90,9 +90,13 @@ testing {
                 implementation(libs.kotlin.test)
                 implementation(libs.ktor.server.test.host)
                 implementation(libs.ktor.client.content.negotation)
+                implementation(libs.ktor.server.auth)
+                implementation(libs.ktor.server.auth.jwt)
 
                 implementation(libs.assertk)
                 implementation(libs.testcontainers.postgresql)
+
+                implementation(libs.mock.oauth2.server)
             }
         }
     }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
@@ -5,8 +5,8 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.config.*
 import io.ktor.server.testing.*
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.testcontainers.containers.PostgreSQLContainer
@@ -14,23 +14,28 @@ import org.testcontainers.containers.PostgreSQLContainer
 abstract class TestApplicationWithDb {
     companion object {
         private val postgresSQLContainer = PostgreSQLContainer("postgres:15-alpine")
+        @JvmStatic
+        protected lateinit var mockOAuthServer : MockOAuth2Server
 
         @BeforeAll
         @JvmStatic
         fun setUp() {
             postgresSQLContainer.withDatabaseName("bygning")
             postgresSQLContainer.start()
+
+            mockOAuthServer = MockOAuth2Server()
+            mockOAuthServer.start()
         }
 
         @AfterAll
         @JvmStatic
         fun tearDown() {
             postgresSQLContainer.stop()
+            mockOAuthServer.shutdown()
         }
 
-        @OptIn(ExperimentalSerializationApi::class)
         fun ApplicationTestBuilder.mainModuleWithDatabaseEnvironmentAndClient(): HttpClient {
-            setDatabaseConfiguration()
+            setTestConfiguration()
 
             application {
                 mainModule()
@@ -48,20 +53,24 @@ abstract class TestApplicationWithDb {
         }
 
         fun ApplicationTestBuilder.internalModuleWithDatabaseEnvironment() {
-            setDatabaseConfiguration()
+            setTestConfiguration()
 
             application {
                 internalModule()
             }
         }
 
-        private fun ApplicationTestBuilder.setDatabaseConfiguration() {
+        private fun ApplicationTestBuilder.setTestConfiguration() {
             environment {
                 config = MapApplicationConfig(
                     "storage.jdbcURL" to postgresSQLContainer.jdbcUrl.removePrefix("jdbc:"),
                     "storage.username" to postgresSQLContainer.username,
                     "storage.password" to postgresSQLContainer.password,
                     "matrikkel.useStub" to "true",
+                    "maskinporten.issuer" to mockOAuthServer.issuerUrl("testIssuer").toString(),
+                    "maskinporten.jwksUri" to mockOAuthServer.jwksUrl("testIssuer").toString(),
+                    "maskinporten.scope" to "kartverket:riktig:scope",
+                    "maskinporten.shouldSkip" to "false"
                 )
             }
         }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/bygning/BygningEksternTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/bygning/BygningEksternTest.kt
@@ -1,0 +1,71 @@
+package no.kartverket.matrikkel.bygning.v1.ekstern.bygning
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import com.nimbusds.jwt.SignedJWT
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import no.kartverket.matrikkel.bygning.TestApplicationWithDb
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.bygning.BygningEksternResponse
+import org.junit.jupiter.api.Test
+
+class BygningEksternTest : TestApplicationWithDb() {
+
+    @Test
+    fun `gitt en gyldig token med riktig scope skal tilgang gis`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val token = signedJWTTokenWithScope()
+
+        val response = client.get("/v1/ekstern/bygninger/1") {
+            headers {
+                append("Authorization", "Bearer ${token.serialize()}")
+            }
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(response.body<BygningEksternResponse>()).all {
+            prop(BygningEksternResponse::bygningId).isEqualTo(1L)
+            prop(BygningEksternResponse::bruksenheter).hasSize(2)
+        }
+    }
+
+    @Test
+    fun `gitt et token med feil scope skal tilgang nektes`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val token = signedJWTTokenWithScope("feil:scope")
+
+        val response = client.get("/v1/ekstern/bygninger/1") {
+            headers {
+                append("Authorization", "Bearer ${token.serialize()}")
+            }
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt et kall uten token skal tilgang nektes`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val response = client.get("/v1/ekstern/bygninger/1")
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    private fun signedJWTTokenWithScope(scope: String = "kartverket:riktig:scope"): SignedJWT {
+        val token: SignedJWT = mockOAuthServer.issueToken(
+            issuerId = "testIssuer",
+            subject = "123456789",
+            claims = mapOf(
+                "scope" to scope,
+                "orgno" to "123456789",
+            ),
+        )
+        return token
+    }
+}

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningRouteTest.kt
@@ -1,4 +1,4 @@
-package no.kartverket.matrikkel.bygning.v1.bygning
+package no.kartverket.matrikkel.bygning.v1.intern.bygning
 
 import assertk.all
 import assertk.assertThat

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
@@ -1,4 +1,4 @@
-package no.kartverket.matrikkel.bygning.v1.egenregistrering
+package no.kartverket.matrikkel.bygning.v1.intern.egenregistrering
 
 import assertk.Assert
 import assertk.all

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -19,6 +19,8 @@ import no.kartverket.matrikkel.bygning.infrastructure.database.repositories.Heal
 import no.kartverket.matrikkel.bygning.infrastructure.database.runFlywayMigrations
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.MatrikkelApiConfig
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.createBygningClient
+import no.kartverket.matrikkel.bygning.plugins.AuthenticationConfig
+import no.kartverket.matrikkel.bygning.plugins.configureMaskinportenAuthentication
 import no.kartverket.matrikkel.bygning.plugins.configureHTTP
 import no.kartverket.matrikkel.bygning.plugins.configureMonitoring
 import no.kartverket.matrikkel.bygning.plugins.configureOpenAPI
@@ -56,6 +58,14 @@ fun Application.mainModule() {
     configureMonitoring()
     configureOpenAPI()
     configureStatusPages()
+    configureMaskinportenAuthentication(
+        AuthenticationConfig(
+            jwksUri = config.property("maskinporten.jwksUri").getString(),
+            issuer = config.property("maskinporten.issuer").getString(),
+            requiredScope = config.property("maskinporten.scope").getString(),
+            shouldSkip = config.propertyOrNull("maskinporten.shouldSkip")?.getString().toBoolean(),
+        ),
+    )
 
     val dataSource = createDataSource(
         DatabaseConfig(

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/Authentication.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/Authentication.kt
@@ -1,0 +1,46 @@
+package no.kartverket.matrikkel.bygning.plugins
+
+import com.auth0.jwk.JwkProviderBuilder
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
+import no.kartverket.matrikkel.bygning.config.Env
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+private val log: Logger = LoggerFactory.getLogger(object {}::class.java)
+
+fun Application.configureMaskinportenAuthentication(config: AuthenticationConfig) {
+    install(Authentication) {
+        jwt("maskinporten") {
+            skipWhen { config.shouldSkipAuthentication() }
+            val jwkProvider = JwkProviderBuilder(URI(config.jwksUri).toURL())
+                .cached(10, 24, TimeUnit.HOURS)
+                .rateLimited(10, 1, TimeUnit.MINUTES)
+                .build()
+
+            verifier(jwkProvider, config.issuer) {
+                acceptLeeway(3)
+                withClaim("scope", config.requiredScope)
+            }
+            validate { it }
+        }
+    }
+}
+
+data class AuthenticationConfig(
+    val jwksUri: String,
+    val issuer: String,
+    val requiredScope: String,
+    private val shouldSkip: Boolean = false,
+) {
+    fun shouldSkipAuthentication(): Boolean {
+        if (Env.isLocal() && shouldSkip) {
+            log.warn("Maskinporten autentisering er deaktivert. Skal kun brukes lokalt!")
+            return true
+        }
+        return false
+    }
+}

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/EksternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/EksternRoutes.kt
@@ -1,6 +1,8 @@
 package no.kartverket.matrikkel.bygning.routes.v1.ekstern
 
 import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.ktor.http.*
+import io.ktor.server.auth.*
 import io.ktor.server.routing.*
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
 import no.kartverket.matrikkel.bygning.routes.v1.ekstern.bygning.bygningEksternRouting
@@ -8,9 +10,20 @@ import no.kartverket.matrikkel.bygning.routes.v1.ekstern.bygning.bygningEksternR
 fun Route.eksternRouting(
     bygningService: BygningService,
 ) {
-    route("/ekstern") {
-        route("bygninger") {
-            bygningEksternRouting(bygningService)
+    authenticate("maskinporten") {
+        route(
+            "/ekstern",
+            {
+                response {
+                    code(HttpStatusCode.Unauthorized) {
+                        description = "Manglende eller ugyldig token"
+                    }
+                }
+            },
+        ) {
+            route("bygninger") {
+                bygningEksternRouting(bygningService)
+            }
         }
     }
 }

--- a/web/src/main/resources/application-local.conf
+++ b/web/src/main/resources/application-local.conf
@@ -14,6 +14,14 @@ matrikkel {
   password = ${?MATRIKKEL_PASSWORD}
 }
 
+maskinporten {
+  jwksUri = "http://localhost"
+  issuer = ""
+  scope = ""
+  // Deaktiverer autentisering med maskinporten ved lokal kjøring
+  shouldSkip = true
+}
+
 // Dette er én løsning for å fikse lokal vs. ikke lokal config
 // Fordelen med å bruke ktor.development flagget er at det også kan brukes til å fikse hot-reloading hvis man ønsker dette
 // Ikke sett på å sette det opp selv

--- a/web/src/main/resources/application.conf
+++ b/web/src/main/resources/application.conf
@@ -5,9 +5,16 @@ storage {
 }
 
 matrikkel {
-  useStub  = false
+  useStub = false
   useStub  = ${?MATRIKKEL_USE_STUB}
   username = ${MATRIKKEL_USERNAME}
   password = ${MATRIKKEL_PASSWORD}
   baseUrl = ${MATRIKKEL_BASE_URL}
 }
+
+maskinporten {
+  jwksUri = ${MASKINPORTEN_JWKS_URI}
+  issuer = ${MASKINPORTEN_ISSUER}
+  scope = ${MASKINPORTEN_SCOPE}
+}
+


### PR DESCRIPTION
Legg til autentisering med maskinporten for eksternt bygning API

* Krever gyldig maskinporten token samt spesifikt scope som er definert i API integrasjonen i maskinporten
* Mulighet til å disable autentisering lokalt (kun mulig å aktivere ved lokal kjøring)
* Bruker mock-oauth2-server fra NAV IKT for integrasjonstester lokalt