### PR TITLE
Fjern Plantegninger som gyldig kildemateriale inkludert validering som ikke lenger er nødvendig

### DIFF
--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/kodelister/EgenregistreringKoder.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/kodelister/EgenregistreringKoder.kt
@@ -61,6 +61,5 @@ enum class KildematerialeKode(
     Selvrapportert("Selvrapportert", "Du har selv gjort en vurdering av hva som er riktig, men har ikke dokumentasjon."),
     Salgsoppgave("Salgsoppgave", "Du har sett dette i salgsoppgaven eller en tilhørende rapport (salgsrapport, tilstandsrapport, boligsalgsrapport, takstrapport osv)."),
     Byggesaksdokumenter("Byggesaksdokumenter", "Du har funnet dette i dokumenter laget i forbindelse med en byggesak, for eksempel tegninger, tillatelser eller ferdigattest."),
-    Plantegninger("Plantegninger", "Hvis du har fått en fagperson til å måle opp og lage nye tegninger til deg."),
     AnnenDokumentasjon("Annen dokumentasjon", "Hvis du har noe dokumentasjon som ikke passer i de andre alternativene, men det er mulig å dokumentere valget ditt.")
 }

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
@@ -15,22 +15,16 @@ import no.kartverket.matrikkel.bygning.application.models.ByggeaarRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bygning
 import no.kartverket.matrikkel.bygning.application.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
-import no.kartverket.matrikkel.bygning.application.models.EnergikildeRegistrering
 import no.kartverket.matrikkel.bygning.application.models.EtasjeBruksarealRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Etasjebetegnelse
 import no.kartverket.matrikkel.bygning.application.models.Etasjenummer
 import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
 import no.kartverket.matrikkel.bygning.application.models.Felt.Byggeaar
 import no.kartverket.matrikkel.bygning.application.models.Multikilde
-import no.kartverket.matrikkel.bygning.application.models.OppvarmingRegistrering
 import no.kartverket.matrikkel.bygning.application.models.RegisterMetadata
 import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Foedselsnummer
-import no.kartverket.matrikkel.bygning.application.models.VannforsyningRegistrering
-import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EtasjeplanKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
-import no.kartverket.matrikkel.bygning.application.models.kodelister.OppvarmingKode
-import no.kartverket.matrikkel.bygning.application.models.kodelister.VannforsyningKode
 import no.kartverket.matrikkel.bygning.application.models.withEgenregistrertData
 import java.time.Instant
 import java.util.*
@@ -74,17 +68,18 @@ class BygningEgenregistreringAggregeringTest {
         eier = Foedselsnummer("31129956715"),
         bygningRegistrering = defaultBygningRegistrering,
     )
+
     private val bruksenhetRegistreringMedKildematerialeKode = BruksenhetRegistrering(
         bruksenhetId = 1L,
         bruksarealRegistrering = BruksarealRegistrering(
             totaltBruksareal = 50.0,
             etasjeRegistreringer = null,
-            kildemateriale = null,
+            kildemateriale = KildematerialeKode.AnnenDokumentasjon,
         ),
         byggeaarRegistrering = ByggeaarRegistrering(2010, KildematerialeKode.Selvrapportert),
-        energikildeRegistrering = EnergikildeRegistrering(listOf(EnergikildeKode.Gass), KildematerialeKode.Byggesaksdokumenter),
-        oppvarmingRegistrering = OppvarmingRegistrering(listOf(OppvarmingKode.Sentralvarme), KildematerialeKode.Salgsoppgave),
-        vannforsyningRegistrering = VannforsyningRegistrering(VannforsyningKode.OffentligVannverk, KildematerialeKode.Plantegninger),
+        energikildeRegistrering = null,
+        oppvarmingRegistrering = null,
+        vannforsyningRegistrering = null,
         avlopRegistrering = null,
     )
 
@@ -102,8 +97,7 @@ class BygningEgenregistreringAggregeringTest {
                         ),
                     ),
                 ),
-
-                ),
+            ),
         )
 
         val aggregatedBygning = defaultBygning.withEgenregistrertData(listOf(laterRegistrering, defaultEgenregistrering))
@@ -133,7 +127,7 @@ class BygningEgenregistreringAggregeringTest {
                         bruksarealRegistrering = BruksarealRegistrering(
                             totaltBruksareal = 150.0,
                             etasjeRegistreringer = null,
-                            kildemateriale = null,
+                            kildemateriale = KildematerialeKode.Byggesaksdokumenter,
                         ),
                     ),
                 ),
@@ -142,7 +136,10 @@ class BygningEgenregistreringAggregeringTest {
 
         val aggregatedBygning = defaultBygning.withEgenregistrertData(listOf(laterRegistrering, defaultEgenregistrering))
 
-        assertThat(aggregatedBygning.bruksenheter.single().totaltBruksareal.egenregistrert?.data).isEqualTo(150.0)
+        assertThat(aggregatedBygning.bruksenheter.single().totaltBruksareal.egenregistrert?.data)
+            .isEqualTo(150.0)
+        assertThat(aggregatedBygning.bruksenheter.single().totaltBruksareal.egenregistrert?.metadata?.kildemateriale)
+            .isEqualTo(KildematerialeKode.Byggesaksdokumenter)
     }
 
     @Test
@@ -164,10 +161,10 @@ class BygningEgenregistreringAggregeringTest {
                                     ),
                                 ),
                             ),
-                            kildemateriale = null
+                            kildemateriale = null,
                         ),
 
-                    ),
+                        ),
                 ),
             ),
         )

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
@@ -1,27 +1,20 @@
 package no.kartverket.matrikkel.bygning.application.egenregistrering
 
 import assertk.assertThat
-import assertk.assertions.any
 import assertk.assertions.contains
 import assertk.assertions.hasSize
-import assertk.assertions.isFalse
 import assertk.assertions.isTrue
-import no.kartverket.matrikkel.bygning.application.models.AvlopRegistrering
 import no.kartverket.matrikkel.bygning.application.models.BruksarealRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
 import no.kartverket.matrikkel.bygning.application.models.BruksenhetRegistrering
-import no.kartverket.matrikkel.bygning.application.models.ByggeaarRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bygning
 import no.kartverket.matrikkel.bygning.application.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
-import no.kartverket.matrikkel.bygning.application.models.EnergikildeRegistrering
 import no.kartverket.matrikkel.bygning.application.models.EtasjeBruksarealRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Etasjebetegnelse
 import no.kartverket.matrikkel.bygning.application.models.Etasjenummer
 import no.kartverket.matrikkel.bygning.application.models.Multikilde
 import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Foedselsnummer
-import no.kartverket.matrikkel.bygning.application.models.kodelister.AvlopKode
-import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EtasjeplanKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
 import java.time.Instant
@@ -48,104 +41,6 @@ class EgenregistreringValidatorTest {
             bruksenhetRegistreringer = emptyList(),
         ),
     )
-
-    @Test
-    fun `egenregistrering med ugyldig kildemateriale for byggeaar skal feile`() {
-        val validationResult = EgenregistreringValidator.validateEgenregistrering(
-            baseEgenregistrering.copy(
-                bygningRegistrering = baseEgenregistrering.bygningRegistrering.copy(
-                    bruksenhetRegistreringer = listOf(
-                        BruksenhetRegistrering(
-                            bruksenhetId = 1L,
-                            byggeaarRegistrering = ByggeaarRegistrering(
-                                byggeaar = 1990,
-                                kildemateriale = KildematerialeKode.Plantegninger,
-                            ),
-                            bruksarealRegistrering = null,
-                            energikildeRegistrering = null,
-                            oppvarmingRegistrering = null,
-                            vannforsyningRegistrering = null,
-                            avlopRegistrering = null,
-                        ),
-                    ),
-                ),
-            ),
-            baseBygning,
-        )
-
-        assertThat(validationResult.isErr).isTrue()
-        assertThat(validationResult.error.errors).hasSize(1)
-        assertThat(validationResult.error.errors.first().message).contains("ID: 1")
-        assertThat(validationResult.error.errors.first().message).contains("kildemateriale: Plantegninger")
-    }
-
-    @Test
-    fun `egenregistrering med gyldig kildemateriale for energikilde skal passere`() {
-        val validationResult = EgenregistreringValidator.validateEgenregistrering(
-            baseEgenregistrering.copy(
-                bygningRegistrering = baseEgenregistrering.bygningRegistrering.copy(
-                    bruksenhetRegistreringer = listOf(
-                        BruksenhetRegistrering(
-                            bruksenhetId = 1L,
-                            bruksarealRegistrering = BruksarealRegistrering(
-                                totaltBruksareal = 125.0,
-                                etasjeRegistreringer = null,
-                                kildemateriale = KildematerialeKode.Plantegninger,
-                            ),
-                            oppvarmingRegistrering = null,
-                            byggeaarRegistrering = null,
-                            vannforsyningRegistrering = null,
-                            energikildeRegistrering = EnergikildeRegistrering(
-                                energikilder = listOf(EnergikildeKode.AnnenEnergikilde),
-                                kildemateriale = KildematerialeKode.Selvrapportert,
-                            ),
-                            avlopRegistrering = null,
-                        ),
-                    ),
-                ),
-            ),
-            baseBygning,
-        )
-
-        assertThat(validationResult.isErr).isFalse()
-    }
-
-    @Test
-    fun `egenregistrering med flere ugyldige kildematerialer skal liste alle feilene`() {
-        val validationResult = EgenregistreringValidator.validateEgenregistrering(
-            baseEgenregistrering.copy(
-                bygningRegistrering = baseEgenregistrering.bygningRegistrering.copy(
-                    bruksenhetRegistreringer = listOf(
-                        BruksenhetRegistrering(
-                            bruksenhetId = 1L,
-                            bruksarealRegistrering = null,
-                            energikildeRegistrering = null,
-                            oppvarmingRegistrering = null,
-                            vannforsyningRegistrering = null,
-                            byggeaarRegistrering = ByggeaarRegistrering(
-                                byggeaar = 1990,
-                                kildemateriale = KildematerialeKode.Plantegninger,
-                            ),
-                            avlopRegistrering = AvlopRegistrering(
-                                avlop = AvlopKode.OffentligKloakk,
-                                kildemateriale = KildematerialeKode.Plantegninger,
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            baseBygning,
-        )
-
-        assertThat(validationResult.isErr).isTrue()
-        assertThat(validationResult.error.errors).hasSize(2)
-        val errorMessages = validationResult.error.errors.map { it.message }
-        assertThat(errorMessages).any { it.contains("ID: 1") }
-        assertThat(errorMessages).any { it.contains("AvlopRegistrering") }
-        assertThat(errorMessages).any { it.contains("ByggeaarRegistrering") }
-        assertThat(errorMessages).any { it.contains("kildemateriale: Plantegninger") }
-    }
-
 
     @Test
     fun `egenregistrering med flere registreringer paa samme bruksenhet skal feile`() {

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/EgenregistreringUtils.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/EgenregistreringUtils.kt
@@ -15,6 +15,8 @@ import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.Bruksen
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.ByggeaarRegistreringRequest
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EgenregistreringRequest
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EnergikildeRegistreringRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EtasjeBetegnelseRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EtasjeBruksarealRegistreringRequest
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.OppvarmingRegistreringRequest
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.VannforsyningRegistreringRequest
 import java.time.Instant
@@ -51,14 +53,26 @@ internal fun EgenregistreringRequest.Companion.validEgenregistrering() = Egenreg
     ),
 )
 
-internal fun EgenregistreringRequest.Companion.invalidEgenregistrering() = EgenregistreringRequest(
+internal fun EgenregistreringRequest.Companion.ugyldigEgenregistreringMedKunBruksarealPerEtasje() = EgenregistreringRequest(
     bygningId = 1L,
     eier = "31129956715",
     bruksenhetRegistreringer = listOf(
         BruksenhetRegistreringRequest(
             bruksenhetId = 1L,
-            byggeaarRegistrering = ByggeaarRegistreringRequest(2010, KildematerialeKode.Plantegninger),
-            bruksarealRegistrering = null,
+            byggeaarRegistrering = null,
+            bruksarealRegistrering = BruksarealRegistreringRequest(
+                totaltBruksareal = null,
+                etasjeRegistreringer = listOf(
+                    EtasjeBruksarealRegistreringRequest(
+                        bruksareal = 125.0,
+                        EtasjeBetegnelseRequest(
+                            etasjeplanKode = "H",
+                            etasjenummer = 1
+                        )
+                    )
+                ),
+                kildemateriale = KildematerialeKode.Salgsoppgave,
+            ),
             energikildeRegistrering = null,
             oppvarmingRegistrering = null,
             vannforsyningRegistrering = null,

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
@@ -37,7 +37,7 @@ import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.Bruksen
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.ByggeaarRegistreringRequest
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EgenregistreringRequest
 import no.kartverket.matrikkel.bygning.v1.common.hasRegistreringstidspunktWithinThreshold
-import no.kartverket.matrikkel.bygning.v1.common.invalidEgenregistrering
+import no.kartverket.matrikkel.bygning.v1.common.ugyldigEgenregistreringMedKunBruksarealPerEtasje
 import no.kartverket.matrikkel.bygning.v1.common.validEgenregistrering
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -286,14 +286,14 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
         }
 
     @Test
-    fun `gitt at egenregistrering feiler skal man få en bad request i respons`() =
+    fun `gitt at egenregistrering inneholder kun BRA per etasje og ikke totalt BRA skal man få en bad request i respons`() =
         testApplication {
             val client = mainModuleWithDatabaseEnvironmentAndClient()
 
             val response = client.post("/v1/egenregistreringer") {
                 contentType(ContentType.Application.Json)
                 setBody(
-                        EgenregistreringRequest.invalidEgenregistrering(),
+                        EgenregistreringRequest.ugyldigEgenregistreringMedKunBruksarealPerEtasje(),
                 )
             }
 

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregisteringRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregisteringRoutes.kt
@@ -49,15 +49,16 @@ fun Route.egenregistreringRouting(egenregistreringService: EgenregistreringServi
                                                     etasjenummer = 2,
                                                 ),
                                             ),
-                                        ), kildemateriale = KildematerialeKode.Plantegninger
+                                        ),
+                                        kildemateriale = KildematerialeKode.Salgsoppgave,
                                     ),
                                     ByggeaarRegistreringRequest(
                                         byggeaar = 2021,
-                                        kildemateriale = KildematerialeKode.Selvrapportert
+                                        kildemateriale = KildematerialeKode.Selvrapportert,
                                     ),
                                     energikildeRegistrering = EnergikildeRegistreringRequest(
                                         energikilder = listOf(EnergikildeKode.Elektrisitet, EnergikildeKode.Gass),
-                                        kildemateriale = KildematerialeKode.Selvrapportert
+                                        kildemateriale = KildematerialeKode.Selvrapportert,
                                     ),
                                     oppvarmingRegistrering = null,
                                     vannforsyningRegistrering = null,


### PR DESCRIPTION
* Slettet valideringskode og tilhørende testkode
* En integrasjonstest som sjekket en ugyldig egenregistrering request er skrevet om til å inneholde en ugyldig BRA request i stedet.