### PR TITLE
Legg til egen user og user_id i dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 FROM eclipse-temurin:21-jdk-alpine
-ENV TZ=Europe/Oslo
+
+ENV USER_ID=150 \
+    USER_NAME=apprunner \
+    TZ=Europe/Oslo
+
+RUN addgroup -g ${USER_ID} ${USER_NAME} \
+    && adduser -u ${USER_ID} -G ${USER_NAME} -D ${USER_NAME}
+
+COPY --chown=${USER_ID}:${USER_ID} /web/build/libs/app.jar /app/app.jar
+
+USER ${USER_NAME}
 EXPOSE ${PORT:-8080}:${PORT:-8080}
-RUN mkdir /app
-COPY /web/build/libs/app.jar /app/app.jar
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
* I praksis kjører vi ikke som root når vi kjører på SKIP, men dette er uansett ryddig å ha på plass
* Vi må benytte UID 150 fordi Skiperator hardkoder denne brukeren når imaget blir kjørt