### PR TITLE
Rename scope -> scopes

### DIFF
--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
@@ -69,7 +69,7 @@ abstract class TestApplicationWithDb {
                     "matrikkel.useStub" to "true",
                     "maskinporten.issuer" to mockOAuthServer.issuerUrl("testIssuer").toString(),
                     "maskinporten.jwksUri" to mockOAuthServer.jwksUrl("testIssuer").toString(),
-                    "maskinporten.scope" to "kartverket:riktig:scope",
+                    "maskinporten.scopes" to "kartverket:riktig:scope",
                     "maskinporten.shouldSkip" to "false"
                 )
             }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -20,8 +20,8 @@ import no.kartverket.matrikkel.bygning.infrastructure.database.runFlywayMigratio
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.MatrikkelApiConfig
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.createBygningClient
 import no.kartverket.matrikkel.bygning.plugins.AuthenticationConfig
-import no.kartverket.matrikkel.bygning.plugins.configureMaskinportenAuthentication
 import no.kartverket.matrikkel.bygning.plugins.configureHTTP
+import no.kartverket.matrikkel.bygning.plugins.configureMaskinportenAuthentication
 import no.kartverket.matrikkel.bygning.plugins.configureMonitoring
 import no.kartverket.matrikkel.bygning.plugins.configureOpenAPI
 import no.kartverket.matrikkel.bygning.plugins.configureStatusPages
@@ -62,7 +62,7 @@ fun Application.mainModule() {
         AuthenticationConfig(
             jwksUri = config.property("maskinporten.jwksUri").getString(),
             issuer = config.property("maskinporten.issuer").getString(),
-            requiredScope = config.property("maskinporten.scope").getString(),
+            requiredScopes = config.property("maskinporten.scopes").getString(),
             shouldSkip = config.propertyOrNull("maskinporten.shouldSkip")?.getString().toBoolean(),
         ),
     )

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/Authentication.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/Authentication.kt
@@ -23,7 +23,7 @@ fun Application.configureMaskinportenAuthentication(config: AuthenticationConfig
 
             verifier(jwkProvider, config.issuer) {
                 acceptLeeway(3)
-                withClaim("scope", config.requiredScope)
+                withClaim("scope", config.requiredScopes)
             }
             validate { it }
         }
@@ -33,7 +33,7 @@ fun Application.configureMaskinportenAuthentication(config: AuthenticationConfig
 data class AuthenticationConfig(
     val jwksUri: String,
     val issuer: String,
-    val requiredScope: String,
+    val requiredScopes: String,
     private val shouldSkip: Boolean = false,
 ) {
     fun shouldSkipAuthentication(): Boolean {

--- a/web/src/main/resources/application.conf
+++ b/web/src/main/resources/application.conf
@@ -15,6 +15,6 @@ matrikkel {
 maskinporten {
   jwksUri = ${MASKINPORTEN_JWKS_URI}
   issuer = ${MASKINPORTEN_ISSUER}
-  scope = ${MASKINPORTEN_SCOPE}
+  scopes = ${MASKINPORTEN_SCOPES}
 }
 


### PR DESCRIPTION
Secret fra digdirator oppretter `MASKINPORTEN_SCOPES`, ikke `MASKINPORTEN_SCOPE`.

Det gir uansett mening ettersom vi kan få flere scopes, ikke bare ett. Disse er i så fall typisk mellomromseparerte.