### PR TITLE
Fiks feil i maskinporten config som gjør at authenticate ikke kan kjøres i endepunkter

### DIFF
--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
@@ -70,7 +70,7 @@ abstract class TestApplicationWithDb {
                     "maskinporten.issuer" to mockOAuthServer.issuerUrl("testIssuer").toString(),
                     "maskinporten.jwksUri" to mockOAuthServer.jwksUrl("testIssuer").toString(),
                     "maskinporten.scopes" to "kartverket:riktig:scope",
-                    "maskinporten.skip" to "false"
+                    "maskinporten.disabled" to "false",
                 )
             }
         }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
@@ -70,7 +70,7 @@ abstract class TestApplicationWithDb {
                     "maskinporten.issuer" to mockOAuthServer.issuerUrl("testIssuer").toString(),
                     "maskinporten.jwksUri" to mockOAuthServer.jwksUrl("testIssuer").toString(),
                     "maskinporten.scopes" to "kartverket:riktig:scope",
-                    "maskinporten.shouldSkip" to "false"
+                    "maskinporten.skip" to "false"
                 )
             }
         }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -11,7 +11,6 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
 import no.kartverket.matrikkel.bygning.application.egenregistrering.EgenregistreringService
 import no.kartverket.matrikkel.bygning.application.health.HealthService
-import no.kartverket.matrikkel.bygning.config.Env.Companion.isMaskinportenDisabled
 import no.kartverket.matrikkel.bygning.config.loadConfiguration
 import no.kartverket.matrikkel.bygning.infrastructure.database.DatabaseConfig
 import no.kartverket.matrikkel.bygning.infrastructure.database.createDataSource
@@ -58,10 +57,7 @@ fun Application.mainModule() {
     configureMonitoring()
     configureOpenAPI()
     configureStatusPages()
-    configureMaskinportenAuthentication(
-        config,
-        isMaskinportenDisabled()
-    )
+    configureMaskinportenAuthentication(config)
 
     val dataSource = createDataSource(
         DatabaseConfig(

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -20,7 +20,6 @@ import no.kartverket.matrikkel.bygning.infrastructure.database.repositories.Heal
 import no.kartverket.matrikkel.bygning.infrastructure.database.runFlywayMigrations
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.MatrikkelApiConfig
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.createBygningClient
-import no.kartverket.matrikkel.bygning.plugins.AuthenticationConfig
 import no.kartverket.matrikkel.bygning.plugins.configureHTTP
 import no.kartverket.matrikkel.bygning.plugins.configureMaskinportenAuthentication
 import no.kartverket.matrikkel.bygning.plugins.configureMonitoring
@@ -59,16 +58,11 @@ fun Application.mainModule() {
     configureMonitoring()
     configureOpenAPI()
     configureStatusPages()
-    if (!isMaskinportenDisabled()) {
-        configureMaskinportenAuthentication(
-            AuthenticationConfig(
-                jwksUri = config.property("maskinporten.jwksUri").getString(),
-                issuer = config.property("maskinporten.issuer").getString(),
-                requiredScopes = config.property("maskinporten.scopes").getString(),
-                shouldSkip = config.propertyOrNull("maskinporten.shouldSkip")?.getString().toBoolean(),
-            ),
-        )
-    }
+    configureMaskinportenAuthentication(
+        config,
+        isMaskinportenDisabled()
+    )
+
     val dataSource = createDataSource(
         DatabaseConfig(
             databaseUrl = config.property("storage.jdbcURL").getString(),

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/config/Env.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/config/Env.kt
@@ -12,9 +12,5 @@ enum class Env {
         }
 
         fun isLocal() = current() == LOCAL
-
-        fun isMaskinportenDisabled(): Boolean {
-            return System.getenv("MASKINPORTEN_DISABLED")?.toBoolean() == true
-        }
     }
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/config/Env.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/config/Env.kt
@@ -14,7 +14,7 @@ enum class Env {
         fun isLocal() = current() == LOCAL
 
         fun isMaskinportenDisabled(): Boolean {
-            return System.getenv("MASKINPORTEN_DISABLED")?.toBoolean() ?: false
+            return System.getenv("MASKINPORTEN_DISABLED")?.toBoolean() == true
         }
     }
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/Authentication.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/Authentication.kt
@@ -13,24 +13,6 @@ import java.util.concurrent.TimeUnit
 
 private val log: Logger = LoggerFactory.getLogger(object {}::class.java)
 
-fun Application.configureMaskinportenAuthentication(config: AuthenticationConfig, isDisabled: Boolean) {
-    install(Authentication) {
-        jwt("maskinporten") {
-            skipWhen { config.shouldSkipAuthentication() || isDisabled }
-            val jwkProvider = JwkProviderBuilder(URI(config.jwksUri).toURL())
-                .cached(10, 24, TimeUnit.HOURS)
-                .rateLimited(10, 1, TimeUnit.MINUTES)
-                .build()
-
-            verifier(jwkProvider, config.issuer) {
-                acceptLeeway(3)
-                withClaim("scope", config.requiredScopes)
-            }
-            validate { it }
-        }
-    }
-}
-
 fun Application.configureMaskinportenAuthentication(config: ApplicationConfig, isDisabled: Boolean) {
     install(Authentication) {
         jwt("maskinporten") {

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/Authentication.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/Authentication.kt
@@ -44,13 +44,13 @@ fun Application.configureMaskinportenAuthentication(config: ApplicationConfig) {
 }
 
 private fun shouldDisableMaskinporten(config: ApplicationConfig): Boolean {
-    val shouldSkip = config.propertyOrNull("maskinporten.disabled")?.getString().toBoolean()
+    val shouldDisable = config.propertyOrNull("maskinporten.disabled")?.getString().toBoolean()
 
-    if (shouldSkip) {
+    if (shouldDisable) {
         log.warn("Maskinporten autentisering er deaktivert! Forsikre deg om at dette ikke skjer utenfor lokale eller utviklingsmiljøer")
     }
 
-    return shouldSkip
+    return shouldDisable
 }
 
 data class AuthenticationConfig(

--- a/web/src/main/resources/application-local.conf
+++ b/web/src/main/resources/application-local.conf
@@ -15,11 +15,9 @@ matrikkel {
 }
 
 maskinporten {
-  jwksUri = "http://localhost"
-  issuer = ""
-  scopes = ""
-  // Deaktiverer autentisering med maskinporten ved lokal kjøring
-  shouldSkip = true
+  jwksUri = ${?MASKINPORTEN_JWKS_URI}
+  issuer = ${?MASKINPORTEN_ISSUER}
+  scopes = ${?MASKINPORTEN_SCOPES}
 }
 
 // Dette er én løsning for å fikse lokal vs. ikke lokal config

--- a/web/src/main/resources/application-local.conf
+++ b/web/src/main/resources/application-local.conf
@@ -18,7 +18,7 @@ maskinporten {
   jwksUri = ${?MASKINPORTEN_JWKS_URI}
   issuer = ${?MASKINPORTEN_ISSUER}
   scopes = ${?MASKINPORTEN_SCOPES}
-  skip = true
+  disabled = true
 }
 
 // Dette er én løsning for å fikse lokal vs. ikke lokal config

--- a/web/src/main/resources/application-local.conf
+++ b/web/src/main/resources/application-local.conf
@@ -18,6 +18,7 @@ maskinporten {
   jwksUri = ${?MASKINPORTEN_JWKS_URI}
   issuer = ${?MASKINPORTEN_ISSUER}
   scopes = ${?MASKINPORTEN_SCOPES}
+  skip = true
 }
 
 // Dette er én løsning for å fikse lokal vs. ikke lokal config

--- a/web/src/main/resources/application.conf
+++ b/web/src/main/resources/application.conf
@@ -16,5 +16,7 @@ maskinporten {
   jwksUri = ${?MASKINPORTEN_JWKS_URI}
   issuer = ${?MASKINPORTEN_ISSUER}
   scopes = ${?MASKINPORTEN_SCOPES}
+  disabled = false
+  disabled = ${?MASKINPORTEN_DISABLED}
 }
 


### PR DESCRIPTION
Fikser en feil som gjorde at `Authentication` plugin ikke ble installert, som førte til at man ikke kunne kjøre applikasjonen med endepunkter som hadde en `authenticate` over seg