### PR TITLE
Konfigurerer OpenAPI generator til å håndtere Instant-typer korrekt

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,8 @@ mockkVersion = "1.13.16"
 assertkVersion = "0.28.1"
 norwegianCommonsVersion = "0.16.0"
 kotlinResultVersion = "2.0.1"
-ktorSwaggerUIVersion = "4.0.0"
+ktorSwaggerUIVersion = "4.1.5"
+smileySchemaKeneratorVersion = "1.6.3"
 mockOauth2Server = "2.1.10"
 
 [libraries]
@@ -55,7 +56,10 @@ norwegian-commons = { group = "no.bekk.bekkopen", name = "nocommons", version.re
 
 kotlin-result = { group = "com.michael-bull.kotlin-result", name = "kotlin-result", version.ref = "kotlinResultVersion" }
 
-ktor-swagger-ui = {group = "io.github.smiley4", name = "ktor-swagger-ui", version.ref = "ktorSwaggerUIVersion"}
+ktor-swagger-ui = { group = "io.github.smiley4", name = "ktor-swagger-ui", version.ref = "ktorSwaggerUIVersion" }
+schema-kenerator-core = { group = "io.github.smiley4", name = "schema-kenerator-core", version.ref = "smileySchemaKeneratorVersion" }
+schema-kenerator-reflection = { group = "io.github.smiley4", name = "schema-kenerator-reflection", version.ref = "smileySchemaKeneratorVersion" }
+schema-kenerator-swagger = { group = "io.github.smiley4", name = "schema-kenerator-swagger", version.ref = "smileySchemaKeneratorVersion" }
 
 [plugins]
 kotlin-jvm = { id = "jvm", version.ref = "kotlinVersion" }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -39,7 +39,10 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx)
 
     // OpenAPI / Swagger
-    implementation (libs.ktor.swagger.ui)
+    implementation(libs.ktor.swagger.ui)
+    implementation(libs.schema.kenerator.core)
+    implementation(libs.schema.kenerator.reflection)
+    implementation(libs.schema.kenerator.swagger)
 }
 
 application {

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
@@ -4,7 +4,22 @@ import io.github.smiley4.ktorswaggerui.SwaggerUI
 import io.github.smiley4.ktorswaggerui.data.AuthScheme
 import io.github.smiley4.ktorswaggerui.data.AuthType
 import io.github.smiley4.ktorswaggerui.dsl.config.PluginConfigDsl
+import io.github.smiley4.schemakenerator.core.connectSubTypes
+import io.github.smiley4.schemakenerator.core.data.AnnotationData
+import io.github.smiley4.schemakenerator.core.data.PrimitiveTypeData
+import io.github.smiley4.schemakenerator.core.data.TypeId
+import io.github.smiley4.schemakenerator.core.handleNameAnnotation
+import io.github.smiley4.schemakenerator.reflection.ReflectionTypeProcessingStepConfig
+import io.github.smiley4.schemakenerator.reflection.collectSubTypes
+import io.github.smiley4.schemakenerator.reflection.processReflection
+import io.github.smiley4.schemakenerator.swagger.compileReferencingRoot
+import io.github.smiley4.schemakenerator.swagger.customizeTypes
+import io.github.smiley4.schemakenerator.swagger.data.TitleType
+import io.github.smiley4.schemakenerator.swagger.generateSwaggerSchema
+import io.github.smiley4.schemakenerator.swagger.handleCoreAnnotations
+import io.github.smiley4.schemakenerator.swagger.withTitle
 import io.ktor.server.application.*
+import java.time.Instant
 
 object OpenApiSpecIds {
     const val INTERN = "intern"
@@ -28,6 +43,26 @@ fun Application.configureOpenAPI() {
 
 private fun PluginConfigDsl.installOpenApiSpec(name: String, title: String, version: String) {
     spec(name) {
+        schemas {
+            generator = { type ->
+                type
+                    .collectSubTypes()
+                    .processReflection(registerCustomProcessors())
+                    .connectSubTypes()
+                    .handleNameAnnotation()
+                    .generateSwaggerSchema()
+                    .handleCoreAnnotations()
+                    .customizeTypes { typeData, typeSchema ->
+                        // Prosesserer alle typer som har fått lagt på en custom annotasjon
+                        typeData.annotations.find { it.name == "type_format_annotation" }?.also { annotation ->
+                            typeSchema.format = annotation.values["format"]?.toString()
+                            typeSchema.types = setOf(annotation.values["type"]?.toString())
+                        }
+                    }
+                    .withTitle(TitleType.SIMPLE)
+                    .compileReferencingRoot()
+            }
+        }
         info {
             this.title = title
             this.version = version
@@ -43,4 +78,35 @@ private fun PluginConfigDsl.installOpenApiSpec(name: String, title: String, vers
             }
         }
     }
+}
+
+private fun registerCustomProcessors(): ReflectionTypeProcessingStepConfig.() -> Unit = {
+    customProcessor<Instant> {
+        createDefaultPrimitiveTypeData<Instant>(
+            type = "string",
+            format = "date-time",
+        )
+    }
+}
+
+/**
+ * Legger på en custom annotasjon som inneholder type og format som senere blir prosessert og gjør at type og format blir satt korret på swagger schema
+ * Bør kunne løses gjennom annotasjoner, men avhengig av et issue som må løses: https://github.com/SMILEY4/schema-kenerator/issues/42
+ */
+private inline fun <reified T> createDefaultPrimitiveTypeData(type: String, format: String): PrimitiveTypeData {
+    return PrimitiveTypeData(
+        id = TypeId.build(T::class.qualifiedName!!),
+        simpleName = T::class.simpleName!!,
+        qualifiedName = T::class.qualifiedName!!,
+        annotations = mutableListOf(
+            AnnotationData(
+                name = "type_format_annotation",
+                values = mutableMapOf(
+                    "type" to type,
+                    "format" to format,
+                ),
+                annotation = null,
+            ),
+        ),
+    )
 }


### PR DESCRIPTION
Setter Instant til type string og format date-time.

* Pga av et issue i smiley4 skjema genereringen (som er rapportert) må vi ha en del logikk for å legge på custom prosessering av Instant-typen.
* Resten generering er hentet fra DEFAULT-generatoren og skal dermed oppføre seg likt som før.

TB-101