### PR TITLE
TS-130 Legg til PAT som env i dependency-submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -16,3 +16,5 @@ jobs:
         uses: ./.github/actions/setup-java
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4
+        env:
+          KV_PACKAGES_PAT: ${{ secrets.KV_PACKAGES_PAT }}


### PR DESCRIPTION
Fiks på forrige [PR](https://github.com/kartverket/matrikkel-bygning-egenregistrering/pull/194). Trenger et PAT for å få hentet ut private GitHub Packages i gradle jobbene, også i denne workflowen. Misset den i forrige PR.

Er det noen flere steder dere kan tenke dere at denne må inn? Hvis noen vet om en bedre/mer sentralisert måte enn å legge den til enn i hver eneste workflow så skrik gjerne ut 😄