### PR TITLE
PAT som env for dependency-sub workflow

### DIFF
--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -16,3 +16,5 @@ jobs:
         uses: ./.github/actions/setup-java
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4
+        env:
+          KV_PACKAGES_PAT: ${{ secrets.KV_PACKAGES_PAT }}


### PR DESCRIPTION
Må også ha PAT for å hente ut pakker via GitHub Packages i denne workflowen. Ble glemt i forrige PR.

TS-130