### PR TITLE
Legg til manglende dependency mot jaxws-rt etter innføring av wsclient

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,11 +47,9 @@ logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.
 postgres = { group = "org.postgresql", name = "postgresql", version.ref = "postgresVersion" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit5", version.ref = "kotlinVersion" }
 jaxws-rt = { group = "com.sun.xml.ws", name = "jaxws-rt", version.ref = "jaxwsVersion" }
-jaxws-tools = { group = "com.sun.xml.ws", name = "jaxws-tools", version.ref = "jaxwsVersion" }
 
 testcontainers-postgresql = { group = "org.testcontainers", name = "postgresql", version.ref = "testcontainersVersion" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockkVersion" }
-mockk-dsl = { group = "io.mockk", name = "mockk-dsl", version.ref = "mockkVersion" }
 mock-oauth2-server = { group = "no.nav.security", name = "mock-oauth2-server", version.ref = "mockOauth2Server" }
 assertk = { group = "com.willowtreeapps.assertk", name = "assertk", version.ref = "assertkVersion" }
 

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
 
     // Matrikkel
     implementation(libs.matrikkelapi.ws.client)
+    runtimeOnly(libs.jaxws.rt) {
+        exclude(group = "org.eclipse.angus") // Ekskluderer angus email
+    }
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
jaxws-rt avhengigheten var definert i modulen matrikkel-api som nå er fjernet. La derfor denne inn igjen i `integration` modulen samme sted som vi trekker wsclient-en. 

Den bør kunne være runtimeOnly da den ikke trengs under bygging/kompilering (og er derfor den først feilet under oppstart av applikasjonen da først er da klassene trengs). 

Gjorde også en liten opprydding i libs.toml og fjernet noen ubrukte definisjoner.

Fint å teste denne i dev-miljøet før vi merger.