### PR TITLE
Forenkle custom prosessering av type og format for Instant i OpenAPI dokumentasjon

### DIFF
--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
@@ -4,16 +4,16 @@ import io.github.smiley4.ktorswaggerui.SwaggerUI
 import io.github.smiley4.ktorswaggerui.data.AuthScheme
 import io.github.smiley4.ktorswaggerui.data.AuthType
 import io.github.smiley4.ktorswaggerui.dsl.config.PluginConfigDsl
+import io.github.smiley4.schemakenerator.core.annotations.Format
+import io.github.smiley4.schemakenerator.core.annotations.Type
 import io.github.smiley4.schemakenerator.core.connectSubTypes
 import io.github.smiley4.schemakenerator.core.data.AnnotationData
 import io.github.smiley4.schemakenerator.core.data.PrimitiveTypeData
 import io.github.smiley4.schemakenerator.core.data.TypeId
 import io.github.smiley4.schemakenerator.core.handleNameAnnotation
-import io.github.smiley4.schemakenerator.reflection.ReflectionTypeProcessingStepConfig
 import io.github.smiley4.schemakenerator.reflection.collectSubTypes
 import io.github.smiley4.schemakenerator.reflection.processReflection
 import io.github.smiley4.schemakenerator.swagger.compileReferencingRoot
-import io.github.smiley4.schemakenerator.swagger.customizeTypes
 import io.github.smiley4.schemakenerator.swagger.data.TitleType
 import io.github.smiley4.schemakenerator.swagger.generateSwaggerSchema
 import io.github.smiley4.schemakenerator.swagger.handleCoreAnnotations
@@ -47,18 +47,18 @@ private fun PluginConfigDsl.installOpenApiSpec(name: String, title: String, vers
             generator = { type ->
                 type
                     .collectSubTypes()
-                    .processReflection(registerCustomProcessors())
+                    .processReflection {
+                        customProcessor<Instant> {
+                            createDefaultPrimitiveTypeWithCustomTypeAndFormat<Instant>(
+                                type = "string",
+                                format = "date-time",
+                            )
+                        }
+                    }
                     .connectSubTypes()
                     .handleNameAnnotation()
                     .generateSwaggerSchema()
                     .handleCoreAnnotations()
-                    .customizeTypes { typeData, typeSchema ->
-                        // Prosesserer alle typer som har fått lagt på en custom annotasjon
-                        typeData.annotations.find { it.name == "type_format_annotation" }?.also { annotation ->
-                            typeSchema.format = annotation.values["format"]?.toString()
-                            typeSchema.types = setOf(annotation.values["type"]?.toString())
-                        }
-                    }
                     .withTitle(TitleType.SIMPLE)
                     .compileReferencingRoot()
             }
@@ -80,32 +80,23 @@ private fun PluginConfigDsl.installOpenApiSpec(name: String, title: String, vers
     }
 }
 
-private fun registerCustomProcessors(): ReflectionTypeProcessingStepConfig.() -> Unit = {
-    customProcessor<Instant> {
-        createDefaultPrimitiveTypeData<Instant>(
-            type = "string",
-            format = "date-time",
-        )
-    }
-}
-
 /**
- * Legger på en custom annotasjon som inneholder type og format som senere blir prosessert og gjør at type og format blir satt korret på swagger schema
- * Bør kunne løses gjennom annotasjoner, men avhengig av et issue som må løses: https://github.com/SMILEY4/schema-kenerator/issues/42
+ * Legger på en type- og format-annotasjoner gjør at type og format blir satt korret på swagger schema
+ * Siden Instant er en ekstern-klasse må vi sette disse som en del av prosessering dynamisk i stedet for å sette annotasjonene direkte på klassen
  */
-private inline fun <reified T> createDefaultPrimitiveTypeData(type: String, format: String): PrimitiveTypeData {
+private inline fun <reified T> createDefaultPrimitiveTypeWithCustomTypeAndFormat(type: String, format: String): PrimitiveTypeData {
     return PrimitiveTypeData(
         id = TypeId.build(T::class.qualifiedName!!),
         simpleName = T::class.simpleName!!,
         qualifiedName = T::class.qualifiedName!!,
         annotations = mutableListOf(
             AnnotationData(
-                name = "type_format_annotation",
-                values = mutableMapOf(
-                    "type" to type,
-                    "format" to format,
-                ),
-                annotation = null,
+                name = Type::class.qualifiedName!!,
+                values = mutableMapOf("type" to type),
+            ),
+            AnnotationData(
+                name = Format::class.qualifiedName!!,
+                values = mutableMapOf("format" to format),
             ),
         ),
     )


### PR DESCRIPTION
I stedet for å legge på en custom annotasjon som post-prosesseres senere legger vi dynamisk på noen innebygde annotasjoner (Type og Format). Disse blir automatisk prosesser og vi kan dermed fjerne custom prosessering.

Grunnen til at vi trenger å legge på annotasjonene dynamisk er at Instant er en ekstern klasse som vi ikke kan annotere direkte.