### PR TITLE
Gjør om BruksenhetId & BygningId til ValueObjects

### DIFF
--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningService.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningService.kt
@@ -35,7 +35,7 @@ class BygningService(
                 val egenregistreringerForBygning = egenregistreringService.findAllEgenregistreringerForBygning(bygningId)
 
                 bygning.bruksenheter
-                    .find { it.bruksenhetId == bruksenhetId }
+                    .find { it.bruksenhetId.value == bruksenhetId }
                     ?.withEgenregistrertData(egenregistreringerForBygning)
                     .toResultOr {
                         BruksenhetNotFound(message = "Bruksenhet finnes ikke på bygningen")

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidator.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidator.kt
@@ -29,8 +29,7 @@ class EgenregistreringValidator {
             egenregistrering: Egenregistrering, bygning: Bygning
         ): ValidationError? {
             val invalidBruksenheter = egenregistrering.bygningRegistrering.bruksenhetRegistreringer.mapNotNull { bruksenhetRegistering ->
-                val bruksenhet = bygning.bruksenheter.find { it.bruksenhetId == bruksenhetRegistering.bruksenhetId }
-
+                val bruksenhet = bygning.bruksenheter.find { it.bruksenhetId.value == bruksenhetRegistering.bruksenhetId }
                 if (bruksenhet == null) {
                     bruksenhetRegistering.bruksenhetId
                 } else {

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BruksenhetId.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BruksenhetId.kt
@@ -1,0 +1,4 @@
+package no.kartverket.matrikkel.bygning.application.models
+
+@JvmInline
+value class BruksenhetId(val value: Long)

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Bygning.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Bygning.kt
@@ -15,7 +15,7 @@ import no.kartverket.matrikkel.bygning.application.models.kodelister.Vannforsyni
 import java.time.Instant
 
 data class Bygning(
-    val bygningId: Long,
+    val bygningId: BygningId,
     val bygningsnummer: Long,
     val etasjer: List<BygningEtasje>,
     val bruksenheter: List<Bruksenhet>,
@@ -52,8 +52,8 @@ sealed interface Felt<T> {
 
 
 data class Bruksenhet(
-    val bruksenhetId: Long,
-    val bygningId: Long,
+    val bruksenhetId: BruksenhetId,
+    val bygningId: BygningId,
     val etasjer: Multikilde<List<BruksenhetEtasje>> = Multikilde(),
     val byggeaar: Multikilde<Byggeaar> = Multikilde(),
     val totaltBruksareal: Multikilde<Bruksareal> = Multikilde(),

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningEgenregistreringAggregering.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningEgenregistreringAggregering.kt
@@ -25,7 +25,7 @@ fun Bygning.withEgenregistrertData(egenregistreringer: List<Egenregistrering>): 
 
 private fun Bruksenhet.applyEgenregistrering(egenregistrering: Egenregistrering): Bruksenhet {
     val bruksenhetRegistrering =
-        egenregistrering.bygningRegistrering.bruksenhetRegistreringer.firstOrNull { it.bruksenhetId == this.bruksenhetId }
+        egenregistrering.bygningRegistrering.bruksenhetRegistreringer.firstOrNull { it.bruksenhetId == this.bruksenhetId.value }
     if (bruksenhetRegistrering == null) {
         return this
     }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningId.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningId.kt
@@ -1,0 +1,5 @@
+package no.kartverket.matrikkel.bygning.application.models
+
+@JvmInline
+value class BygningId(val value: Long) {
+}

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
@@ -10,9 +10,11 @@ import assertk.assertions.prop
 import no.kartverket.matrikkel.bygning.application.models.BruksarealRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
 import no.kartverket.matrikkel.bygning.application.models.BruksenhetEtasje
+import no.kartverket.matrikkel.bygning.application.models.BruksenhetId
 import no.kartverket.matrikkel.bygning.application.models.BruksenhetRegistrering
 import no.kartverket.matrikkel.bygning.application.models.ByggeaarRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bygning
+import no.kartverket.matrikkel.bygning.application.models.BygningId
 import no.kartverket.matrikkel.bygning.application.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
 import no.kartverket.matrikkel.bygning.application.models.EtasjeBruksarealRegistrering
@@ -33,12 +35,12 @@ import kotlin.test.Test
 
 class BygningEgenregistreringAggregeringTest {
     private val defaultBruksenhet = Bruksenhet(
-        bruksenhetId = 1L,
-        bygningId = 1L,
+        bruksenhetId = BruksenhetId(1L),
+        bygningId = BygningId(1L),
     )
 
     private val defaultBygning = Bygning(
-        bygningId = 1L,
+        bygningId = BygningId(1L),
         bygningsnummer = 100,
         bruksenheter = listOf(defaultBruksenhet),
         etasjer = emptyList(),

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
@@ -6,8 +6,10 @@ import assertk.assertions.hasSize
 import assertk.assertions.isTrue
 import no.kartverket.matrikkel.bygning.application.models.BruksarealRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import no.kartverket.matrikkel.bygning.application.models.BruksenhetId
 import no.kartverket.matrikkel.bygning.application.models.BruksenhetRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bygning
+import no.kartverket.matrikkel.bygning.application.models.BygningId
 import no.kartverket.matrikkel.bygning.application.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
 import no.kartverket.matrikkel.bygning.application.models.EtasjeBruksarealRegistrering
@@ -24,10 +26,10 @@ import kotlin.test.Test
 
 class EgenregistreringValidatorTest {
     private val baseBygning = Bygning(
-        bygningId = 1L, bygningsnummer = 100L,
+        bygningId = BygningId(1L), bygningsnummer = 100L,
         bruksenheter = listOf(
             Bruksenhet(
-                bruksenhetId = 1L, bygningId = 1L, etasjer = Multikilde(),
+                bruksenhetId = BruksenhetId(1L), bygningId = BygningId(1L), etasjer = Multikilde(),
             ),
         ),
         etasjer = emptyList(),

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/LocalBygningClient.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/LocalBygningClient.kt
@@ -4,7 +4,9 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.toResultOr
 import no.kartverket.matrikkel.bygning.application.bygning.BygningClient
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import no.kartverket.matrikkel.bygning.application.models.BruksenhetId
 import no.kartverket.matrikkel.bygning.application.models.Bygning
+import no.kartverket.matrikkel.bygning.application.models.BygningId
 import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
 import no.kartverket.matrikkel.bygning.application.models.Multikilde
 import no.kartverket.matrikkel.bygning.application.models.RegisterMetadata
@@ -16,26 +18,26 @@ import java.time.Instant
 class LocalBygningClient : BygningClient {
     private val bruksenheter: List<Bruksenhet> = listOf(
         Bruksenhet(
-            bruksenhetId = 1L,
-            bygningId = 1L,
+            bruksenhetId = BruksenhetId(1L),
+            bygningId = BygningId(1L),
         ),
         Bruksenhet(
-            bruksenhetId = 2L,
-            bygningId = 1L,
+            bruksenhetId = BruksenhetId(2L),
+            bygningId = BygningId(1L),
         ),
         Bruksenhet(
-            bruksenhetId = 3L,
-            bygningId = 2L,
+            bruksenhetId = BruksenhetId(3L),
+            bygningId = BygningId(2L),
         ),
         Bruksenhet(
-            bruksenhetId = 4L,
-            bygningId = 2L,
+            bruksenhetId = BruksenhetId(4L),
+            bygningId = BygningId(2L),
         ),
     )
 
     private val bygninger: List<Bygning> = listOf(
         Bygning(
-            bygningId = 1L,
+            bygningId = BygningId(1L),
             bygningsnummer = 100L,
             bruksenheter = bruksenheter.subList(0, 2),
             bruksareal = Multikilde(
@@ -52,7 +54,7 @@ class LocalBygningClient : BygningClient {
             etasjer = emptyList(),
         ),
         Bygning(
-            bygningId = 2L,
+            bygningId = BygningId(2L),
             bygningsnummer = 200L,
             bruksenheter = bruksenheter.subList(2, 4),
             etasjer = emptyList(),
@@ -61,7 +63,7 @@ class LocalBygningClient : BygningClient {
 
     override fun getBygningById(id: Long): Result<Bygning, DomainError> {
         return bygninger
-            .find { it.bygningId == id }
+            .find { it.bygningId.value == id }
             .toResultOr {
                 BygningNotFound(message = "Bygning med ID $id finnes ikke i matrikkelen")
             }

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/MatrikkelBygningClient.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/MatrikkelBygningClient.kt
@@ -5,8 +5,10 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import no.kartverket.matrikkel.bygning.application.bygning.BygningClient
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import no.kartverket.matrikkel.bygning.application.models.BruksenhetId
 import no.kartverket.matrikkel.bygning.application.models.Bygning
 import no.kartverket.matrikkel.bygning.application.models.BygningEtasje
+import no.kartverket.matrikkel.bygning.application.models.BygningId
 import no.kartverket.matrikkel.bygning.application.models.Etasjebetegnelse
 import no.kartverket.matrikkel.bygning.application.models.Etasjenummer
 import no.kartverket.matrikkel.bygning.application.models.Felt.Avlop
@@ -24,7 +26,7 @@ import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.getBruksenheter
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.getBygning
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.id.bygningId
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.toInstant
-import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningId
+import no.statkart.matrikkel.matrikkelapi.wsapi.v1.domain.bygning.BygningId as MatrikkelBygningId
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.service.store.ServiceException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -36,7 +38,7 @@ class MatrikkelBygningClient(
     private val log: Logger = LoggerFactory.getLogger(javaClass)
 
     override fun getBygningById(id: Long): Result<Bygning, DomainError> {
-        val bygningId: BygningId = bygningId(id)
+        val bygningId: MatrikkelBygningId = bygningId(id)
 
         try {
             val bygning = matrikkelApi.storeService().getBygning(bygningId, matrikkelApi.matrikkelContext)
@@ -51,7 +53,7 @@ class MatrikkelBygningClient(
 
             return Ok(
                 Bygning(
-                    bygningId = bygning.id.value,
+                    bygningId = BygningId(bygning.id.value),
                     bygningsnummer = bygning.bygningsnummer,
                     byggeaar = Multikilde(
                         autoritativ = deriveByggeaarForBygning(bygning),
@@ -109,8 +111,8 @@ class MatrikkelBygningClient(
                         )
 
                         Bruksenhet(
-                            bruksenhetId = it.id.value,
-                            bygningId = it.byggId.value,
+                            bruksenhetId = BruksenhetId(it.id.value),
+                            bygningId = BygningId(it.byggId.value),
                             // TODO: Hvordan innse at arealet er ukjent og hvordan håndtere dette
                             totaltBruksareal = Multikilde(
                                 autoritativ = Bruksareal(

--- a/infrastructure/src/test/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/MatrikkelBygningClientTest.kt
+++ b/infrastructure/src/test/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/MatrikkelBygningClientTest.kt
@@ -14,7 +14,9 @@ import io.mockk.checkUnnecessaryStub
 import io.mockk.every
 import io.mockk.mockk
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import no.kartverket.matrikkel.bygning.application.models.BruksenhetId
 import no.kartverket.matrikkel.bygning.application.models.Bygning
+import no.kartverket.matrikkel.bygning.application.models.BygningId
 import no.kartverket.matrikkel.bygning.application.models.Felt.Avlop
 import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
 import no.kartverket.matrikkel.bygning.application.models.Felt.Energikilde
@@ -85,7 +87,7 @@ class MatrikkelBygningClientTest {
         val isMatrikkelfoertBruksenhetstidspunkt = createIsMatrikkelfoertAssert(Instant.parse("2024-09-12T00:00:00.00Z"))
 
         assertThat(bygning.value, "bygning").all {
-            prop(Bygning::bygningId).isEqualTo(1L)
+            prop(Bygning::bygningId).isEqualTo(BygningId(1L))
             prop(Bygning::bygningsnummer).isEqualTo(1000L)
             prop(Bygning::bruksareal).erAutoritativIkkeEgenregistrert {
                 // TODO: Dette skal egentlig være "vet ikke", som kanskje ikke skal representeres slik
@@ -97,8 +99,8 @@ class MatrikkelBygningClientTest {
             prop(Bygning::energikilder).isEmpty()
             prop(Bygning::oppvarminger).isEmpty()
             prop(Bygning::bruksenheter).single().all {
-                prop(Bruksenhet::bruksenhetId).isEqualTo(2L)
-                prop(Bruksenhet::bygningId).isEqualTo(1L)
+                prop(Bruksenhet::bruksenhetId).isEqualTo(BruksenhetId(2L))
+                prop(Bruksenhet::bygningId).isEqualTo(BygningId(1L))
                 prop(Bruksenhet::totaltBruksareal).erAutoritativIkkeEgenregistrert {
                     // TODO: Dette skal egentlig være "vet ikke", som kanskje ikke skal representeres slik
                     prop(Bruksareal::data).isEqualTo(0.0)
@@ -163,7 +165,7 @@ class MatrikkelBygningClientTest {
         val isMatrikkelfoertBruksenhetstidspunkt = createIsMatrikkelfoertAssert(Instant.parse("2024-09-13T00:00:00.00Z"))
 
         assertThat(bygning.value, "bygning").isNotNull().all {
-            prop(Bygning::bygningId).isEqualTo(1L)
+            prop(Bygning::bygningId).isEqualTo(BygningId(1L))
             prop(Bygning::bygningsnummer).isEqualTo(1000L)
             prop(Bygning::bruksareal).erAutoritativIkkeEgenregistrert {
                 prop(Bruksareal::data).isEqualTo(150.0)
@@ -196,8 +198,8 @@ class MatrikkelBygningClientTest {
                 }
             }
             prop(Bygning::bruksenheter).single().all {
-                prop(Bruksenhet::bruksenhetId).isEqualTo(2L)
-                prop(Bruksenhet::bygningId).isEqualTo(1L)
+                prop(Bruksenhet::bruksenhetId).isEqualTo(BruksenhetId(2L))
+                prop(Bruksenhet::bygningId).isEqualTo(BygningId(1L))
                 prop(Bruksenhet::totaltBruksareal).erAutoritativIkkeEgenregistrert {
                     prop(Bruksareal::data).isEqualTo(140.0)
                     prop(Bruksareal::metadata).isMatrikkelfoertBruksenhetstidspunkt()

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/bygning/BygningEksternResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/bygning/BygningEksternResponse.kt
@@ -84,7 +84,7 @@ data class RegisterMetadataEksternResponse(
 
 
 fun Bygning.toBygningEksternResponse(): BygningEksternResponse = BygningEksternResponse(
-    bygningId = bygningId,
+    bygningId = bygningId.value,
     bygningsnummer = bygningsnummer,
     bruksenheter = bruksenheter.map {
         it.toBruksenhetEksternResponse()
@@ -109,7 +109,7 @@ private fun <U, T : Felt<U?>, O : FeltEksternResponse<U>?> toFeltEksternResponse
 }
 
 private fun Bruksenhet.toBruksenhetEksternResponse(): BruksenhetEksternResponse = BruksenhetEksternResponse(
-    bruksenhetId = this.bruksenhetId,
+    bruksenhetId = this.bruksenhetId.value,
     byggeaar = toFeltEksternResponse(this.byggeaar.egenregistrert, ::ByggeaarEksternResponse),
     totaltBruksareal = toFeltEksternResponse(this.totaltBruksareal.egenregistrert, ::BruksarealEksternResponse),
     vannforsyning = toFeltEksternResponse(this.vannforsyning.egenregistrert, ::VannforsyningKodeEksternResponse),

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningResponse.kt
@@ -112,7 +112,7 @@ fun <T : Any, R : Any> Multikilde<T>.toMultikildeResponse(mapper: T.() -> R): Mu
 }
 
 fun Bygning.toBygningResponse(): BygningResponse = BygningResponse(
-    bygningId = this.bygningId,
+    bygningId = this.bygningId.value,
     bygningsnummer = this.bygningsnummer,
     byggeaar = this.byggeaar.toMultikildeResponse(Byggeaar::toByggeaarResponse),
     bruksareal = this.bruksareal.toMultikildeResponse(Bruksareal::toBruksarealResponse),
@@ -124,13 +124,13 @@ fun Bygning.toBygningResponse(): BygningResponse = BygningResponse(
 )
 
 fun Bygning.toBygningSimpleResponseFromEgenregistrertData(): BygningSimpleResponse = BygningSimpleResponse(
-    bygningId = this.bygningId,
+    bygningId = this.bygningId.value,
     bygningsnummer = this.bygningsnummer,
     bruksenheter = this.bruksenheter.map { it.toBruksenhetSimpleResponseFromEgenregistrertData() },
 )
 
 fun Bruksenhet.toBruksenhetResponse(): BruksenhetResponse = BruksenhetResponse(
-    bruksenhetId = this.bruksenhetId,
+    bruksenhetId = this.bruksenhetId.value,
     byggeaar = this.byggeaar.toMultikildeResponse(Byggeaar::toByggeaarResponse),
     etasjer = this.etasjer.toMultikildeResponse { map(BruksenhetEtasje::toBruksenhetEtasjeResponse) },
     totaltBruksareal = this.totaltBruksareal.toMultikildeResponse(Bruksareal::toBruksarealResponse),
@@ -141,7 +141,7 @@ fun Bruksenhet.toBruksenhetResponse(): BruksenhetResponse = BruksenhetResponse(
 )
 
 fun Bruksenhet.toBruksenhetSimpleResponseFromEgenregistrertData(): BruksenhetSimpleResponse = BruksenhetSimpleResponse(
-    bruksenhetId = this.bruksenhetId,
+    bruksenhetId = this.bruksenhetId.value,
     byggeaar = this.byggeaar.egenregistrert?.toByggeaarResponse(),
     etasjer = this.etasjer.egenregistrert?.map { it.toBruksenhetEtasjeResponse() },
     totaltBruksareal = this.totaltBruksareal.egenregistrert?.toBruksarealResponse(),


### PR DESCRIPTION
* Endringen en at vi bruker primitive typer som egentlig kan være en egen type.  Typisk vil typene bli brukt i domene/applikasjonslaget, mens man i Request/Response-objektene vil bevare primitive typer for serialisering/deserialisering. Dette omhandler BruksenhetId.kt og BygningId.kt

* TB-135