### PR TITLE
Materialisering av bruksenhet ved innkommende egenregistreringer

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -5,7 +5,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 
 plugins {
     kotlin("jvm")
-    kotlin("plugin.serialization").version(libs.versions.kotlinVersion)
 
     `jvm-test-suite`
 }
@@ -15,8 +14,7 @@ dependencies {
     api(libs.kotlin.result)
 
     // Serialization
-    // TODO: Bør helst ikke måtte ligge i application (skyldes lagring i databasen)
-    implementation(libs.ktor.serialization.kotlinx)
+    implementation(libs.fasterxml.jackson.kotlin)
 
     // Norwegian Commons
     implementation(libs.norwegian.commons)

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningClient.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningClient.kt
@@ -5,7 +5,7 @@ import no.kartverket.matrikkel.bygning.application.models.Bygning
 import no.kartverket.matrikkel.bygning.application.models.error.DomainError
 
 interface BygningClient {
-    fun getBygningById(id: Long): Result<Bygning, DomainError>
+    fun getBygningByBubbleId(bygningBubbleId: Long): Result<Bygning, DomainError>
 
     fun getBygningByBygningsnummer(bygningsnummer: Long): Result<Bygning, DomainError>
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningRepository.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningRepository.kt
@@ -1,0 +1,10 @@
+package no.kartverket.matrikkel.bygning.application.bygning
+
+import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import java.util.*
+
+interface BygningRepository {
+    fun saveBruksenhet(bruksenhet: Bruksenhet)
+
+    fun getBruksenhetById(bruksenhetId: UUID): Bruksenhet?
+}

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringRepository.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringRepository.kt
@@ -3,6 +3,5 @@ package no.kartverket.matrikkel.bygning.application.egenregistrering
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
 
 interface EgenregistreringRepository {
-    fun getAllEgenregistreringerForBygning(bygningId: Long): List<Egenregistrering>
     fun saveEgenregistrering(egenregistrering: Egenregistrering)
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringService.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringService.kt
@@ -2,27 +2,23 @@ package no.kartverket.matrikkel.bygning.application.egenregistrering
 
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
-import com.github.michaelbull.result.onSuccess
-import no.kartverket.matrikkel.bygning.application.bygning.BygningClient
+import com.github.michaelbull.result.map
+import no.kartverket.matrikkel.bygning.application.bygning.BygningService
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
 import no.kartverket.matrikkel.bygning.application.models.error.DomainError
 
 class EgenregistreringService(
-    private val bygningClient: BygningClient,
+    private val bygningService: BygningService,
     private val egenregistreringRepository: EgenregistreringRepository,
 ) {
     fun addEgenregistrering(egenregistrering: Egenregistrering): Result<Unit, DomainError> {
-        return bygningClient
-            .getBygningById(egenregistrering.bygningRegistrering.bygningId)
-            .andThen {
-                EgenregistreringValidator.validateEgenregistrering(egenregistrering, it)
+        return bygningService.getBygningByBubbleId(egenregistrering.bygningRegistrering.bygningBubbleId.value)
+            .andThen { bygning ->
+                EgenregistreringValidator.validateEgenregistrering(egenregistrering, bygning).map { bygning }
             }
-            .onSuccess {
+            .map { bygning ->
                 egenregistreringRepository.saveEgenregistrering(egenregistrering)
+                bygningService.createBruksenhetSnapshotsOfEgenregistrering(bygning, egenregistrering)
             }
-    }
-
-    fun findAllEgenregistreringerForBygning(bygningId: Long): List<Egenregistrering> {
-        return egenregistreringRepository.getAllEgenregistreringerForBygning(bygningId)
     }
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidator.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidator.kt
@@ -28,9 +28,10 @@ class EgenregistreringValidator {
             egenregistrering: Egenregistrering, bygning: Bygning
         ): ValidationError? {
             val invalidBruksenheter = egenregistrering.bygningRegistrering.bruksenhetRegistreringer.mapNotNull { bruksenhetRegistering ->
-                val bruksenhet = bygning.bruksenheter.find { it.bruksenhetId.value == bruksenhetRegistering.bruksenhetId }
+                val bruksenhet = bygning.bruksenheter.find { it.bruksenhetBubbleId == bruksenhetRegistering.bruksenhetBubbleId }
+
                 if (bruksenhet == null) {
-                    bruksenhetRegistering.bruksenhetId
+                    bruksenhetRegistering.bruksenhetBubbleId
                 } else {
                     null
                 }
@@ -38,7 +39,7 @@ class EgenregistreringValidator {
 
             if (invalidBruksenheter.isNotEmpty()) {
                 return ValidationError(
-                    message = "Bruksenhet${if (invalidBruksenheter.size > 1) "er" else ""} med ID ${invalidBruksenheter.joinToString()} finnes ikke i bygning med ID ${bygning.bygningId}",
+                    message = "Bruksenhet${if (invalidBruksenheter.size > 1) "er" else ""} med ID ${invalidBruksenheter.joinToString()} finnes ikke i bygning med ID ${bygning.bygningBubbleId}",
                 )
             }
 
@@ -47,7 +48,7 @@ class EgenregistreringValidator {
 
         private fun validateRepeatedBruksenheter(egenregistrering: Egenregistrering): ValidationError? {
             val repeatedBruksenheter =
-                egenregistrering.bygningRegistrering.bruksenhetRegistreringer.groupBy { it.bruksenhetId }.filter { it.value.size > 1 }
+                egenregistrering.bygningRegistrering.bruksenhetRegistreringer.groupBy { it.bruksenhetBubbleId }.filter { it.value.size > 1 }
                     .map { it.key }
 
 
@@ -67,7 +68,7 @@ class EgenregistreringValidator {
                 }
                 .map { invalidRegistrering ->
                     ValidationError(
-                        message = "Bruksenhet med ID ${invalidRegistrering.bruksenhetId} har registrert totalt BRA og BRA per etasje, men totalt BRA stemmer ikke overens med totalen av BRA per etasje",
+                        message = "Bruksenhet med ID ${invalidRegistrering.bruksenhetBubbleId} har registrert totalt BRA og BRA per etasje, men totalt BRA stemmer ikke overens med totalen av BRA per etasje",
                     )
                 }
 

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BruksenhetId.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BruksenhetId.kt
@@ -1,4 +1,0 @@
-package no.kartverket.matrikkel.bygning.application.models
-
-@JvmInline
-value class BruksenhetId(val value: Long)

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Bygning.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Bygning.kt
@@ -7,6 +7,10 @@ import no.kartverket.matrikkel.bygning.application.models.Felt.Byggeaar
 import no.kartverket.matrikkel.bygning.application.models.Felt.Energikilde
 import no.kartverket.matrikkel.bygning.application.models.Felt.Oppvarming
 import no.kartverket.matrikkel.bygning.application.models.Felt.Vannforsyning
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningId
 import no.kartverket.matrikkel.bygning.application.models.kodelister.AvlopKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
@@ -16,7 +20,8 @@ import no.kartverket.matrikkel.bygning.application.models.kodelister.Vannforsyni
 import java.time.Instant
 
 data class Bygning(
-    val bygningId: BygningId,
+    val id: BygningId,
+    val bygningBubbleId: BygningBubbleId,
     val bygningsnummer: Long,
     val etasjer: List<BygningEtasje>,
     val bruksenheter: List<Bruksenhet>,
@@ -52,9 +57,9 @@ sealed interface Felt<T> {
     data class Oppvarming(override val data: List<OppvarmingKode>, override val metadata: RegisterMetadata) : Felt<List<OppvarmingKode>>
 }
 
-
 data class Bruksenhet(
-    val bruksenhetId: BruksenhetId,
+    val id: BruksenhetId,
+    val bruksenhetBubbleId: BruksenhetBubbleId,
     val bygningId: BygningId,
     val etasjer: Multikilde<BruksenhetEtasjer> = Multikilde(),
     val byggeaar: Multikilde<Byggeaar> = Multikilde(),
@@ -64,3 +69,4 @@ data class Bruksenhet(
     val vannforsyning: Multikilde<Vannforsyning> = Multikilde(),
     val avlop: Multikilde<Avlop> = Multikilde(),
 )
+

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningId.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningId.kt
@@ -1,5 +1,0 @@
-package no.kartverket.matrikkel.bygning.application.models
-
-@JvmInline
-value class BygningId(val value: Long) {
-}

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Egenregistrering.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Egenregistrering.kt
@@ -1,7 +1,8 @@
 package no.kartverket.matrikkel.bygning.application.models
 
-import kotlinx.serialization.Serializable
 import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Foedselsnummer
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningBubbleId
 import no.kartverket.matrikkel.bygning.application.models.kodelister.AvlopKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
@@ -15,13 +16,11 @@ sealed interface HasKildemateriale {
     val kildemateriale: KildematerialeKode
 }
 
-@Serializable
 data class ByggeaarRegistrering(
     val byggeaar: Int,
     override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
-@Serializable
 data class BruksarealRegistrering(
     val totaltBruksareal: Double,
     val etasjeRegistreringer: List<EtasjeBruksarealRegistrering>?,
@@ -40,46 +39,39 @@ data class BruksarealRegistrering(
     }
 }
 
-@Serializable
 data class EtasjeBruksarealRegistrering(
     val bruksareal: Double,
     val etasjebetegnelse: Etasjebetegnelse,
 )
 
-@Serializable
 data class VannforsyningRegistrering(
     val vannforsyning: VannforsyningKode,
     override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
-@Serializable
 data class AvlopRegistrering(
     val avlop: AvlopKode,
     override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
-@Serializable
 data class EnergikildeRegistrering(
     val energikilder: List<EnergikildeKode>,
     override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
-@Serializable
 data class OppvarmingRegistrering(
     val oppvarminger: List<OppvarmingKode>,
     override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
 
-@Serializable
 data class BygningRegistrering(
-    val bygningId: Long,
+    val bygningBubbleId: BygningBubbleId,
     val bruksenhetRegistreringer: List<BruksenhetRegistrering>
 )
 
-@Serializable
 data class BruksenhetRegistrering(
-    val bruksenhetId: Long,
+    val bruksenhetBubbleId: BruksenhetBubbleId,
     val bruksarealRegistrering: BruksarealRegistrering?,
     val byggeaarRegistrering: ByggeaarRegistrering?,
     val vannforsyningRegistrering: VannforsyningRegistrering?,

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Etasje.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Etasje.kt
@@ -1,14 +1,11 @@
 package no.kartverket.matrikkel.bygning.application.models
 
-import kotlinx.serialization.Serializable
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EtasjeplanKode
 
 data class BygningEtasje(val etasjebetegnelse: Etasjebetegnelse, val etasjeId: Long)
 
 data class BruksenhetEtasje(val etasjebetegnelse: Etasjebetegnelse, val bruksareal: Double)
 
-@ConsistentCopyVisibility
-@Serializable
 data class Etasjenummer private constructor(val loepenummer: Int) {
     companion object {
         fun of(loepenummer: Int): Etasjenummer {
@@ -26,8 +23,6 @@ data class Etasjenummer private constructor(val loepenummer: Int) {
     }
 }
 
-@ConsistentCopyVisibility
-@Serializable
 data class Etasjebetegnelse private constructor(
     val etasjeplanKode: EtasjeplanKode,
     val etasjenummer: Etasjenummer,

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/RegistreringAktoer.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/RegistreringAktoer.kt
@@ -1,10 +1,23 @@
 package no.kartverket.matrikkel.bygning.application.models
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
 import no.bekk.bekkopen.person.FodselsnummerValidator
+import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Foedselsnummer
+import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Signatur
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.PROPERTY)
+@JsonSubTypes(
+    value = [
+        JsonSubTypes.Type(value = Foedselsnummer::class, name = "foedselsnummer"),
+        JsonSubTypes.Type(value = Signatur::class, name = "signatur")
+    ]
+)
 sealed class RegistreringAktoer {
     abstract val value: String
 
+    @JsonTypeName("foedselsnummer")
     data class Foedselsnummer(override val value: String) : RegistreringAktoer() {
         init {
             // TODO Dette burde ikke være lov når vi er i prod, da må vi sjekke miljøet vi er i
@@ -15,8 +28,9 @@ sealed class RegistreringAktoer {
             }
         }
 
-        fun getMaskedValue(): String = value.replace(Regex("\\d"), "*")
+        fun toMaskedValue(): String = value.replace(Regex("\\d"), "*")
     }
 
+    @JsonTypeName("signatur")
     data class Signatur(override val value: String) : RegistreringAktoer()
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/ids/BruksenhetBubbleId.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/ids/BruksenhetBubbleId.kt
@@ -1,0 +1,4 @@
+package no.kartverket.matrikkel.bygning.application.models.ids
+
+@JvmInline
+value class BruksenhetBubbleId(val value: Long)

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/ids/BruksenhetId.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/ids/BruksenhetId.kt
@@ -1,0 +1,16 @@
+package no.kartverket.matrikkel.bygning.application.models.ids
+
+import java.util.*
+
+@JvmInline
+value class BruksenhetId(
+    val value: UUID
+) {
+    companion object {
+        operator fun invoke(uuidString: String): BruksenhetId =
+            BruksenhetId(UUID.fromString(uuidString))
+
+        operator fun invoke(uuid: UUID): BruksenhetId =
+            BruksenhetId(uuid)
+    }
+}

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/ids/BygningBubbleId.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/ids/BygningBubbleId.kt
@@ -1,0 +1,4 @@
+package no.kartverket.matrikkel.bygning.application.models.ids
+
+@JvmInline
+value class BygningBubbleId(val value: Long)

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/ids/BygningId.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/ids/BygningId.kt
@@ -1,0 +1,16 @@
+package no.kartverket.matrikkel.bygning.application.models.ids
+
+import java.util.*
+
+@JvmInline
+value class BygningId(
+    val value: UUID
+) {
+    companion object {
+        operator fun invoke(uuidString: String): BygningId =
+            BygningId(UUID.fromString(uuidString))
+
+        operator fun invoke(uuid: UUID): BygningId =
+            BygningId(uuid)
+    }
+}

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
@@ -6,10 +6,8 @@ import assertk.assertions.hasSize
 import assertk.assertions.isTrue
 import no.kartverket.matrikkel.bygning.application.models.BruksarealRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
-import no.kartverket.matrikkel.bygning.application.models.BruksenhetId
 import no.kartverket.matrikkel.bygning.application.models.BruksenhetRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bygning
-import no.kartverket.matrikkel.bygning.application.models.BygningId
 import no.kartverket.matrikkel.bygning.application.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
 import no.kartverket.matrikkel.bygning.application.models.EtasjeBruksarealRegistrering
@@ -17,6 +15,10 @@ import no.kartverket.matrikkel.bygning.application.models.Etasjebetegnelse
 import no.kartverket.matrikkel.bygning.application.models.Etasjenummer
 import no.kartverket.matrikkel.bygning.application.models.Multikilde
 import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Foedselsnummer
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningId
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EtasjeplanKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.ProsessKode
@@ -25,11 +27,17 @@ import java.util.*
 import kotlin.test.Test
 
 class EgenregistreringValidatorTest {
+    val bygningId = BygningId("00000000-0000-0000-0000-000000000001")
+
     private val baseBygning = Bygning(
-        bygningId = BygningId(1L), bygningsnummer = 100L,
+        id = bygningId,
+        bygningBubbleId = BygningBubbleId(1L), bygningsnummer = 100L,
         bruksenheter = listOf(
             Bruksenhet(
-                bruksenhetId = BruksenhetId(1L), bygningId = BygningId(1L), etasjer = Multikilde(),
+                id = BruksenhetId("00000000-0000-0000-0001-000000000001"),
+                bruksenhetBubbleId = BruksenhetBubbleId(1L),
+                bygningId = bygningId,
+                etasjer = Multikilde(),
             ),
         ),
         etasjer = emptyList(),
@@ -41,7 +49,7 @@ class EgenregistreringValidatorTest {
         eier = Foedselsnummer("31129956715"),
         prosess = ProsessKode.Egenregistrering,
         bygningRegistrering = BygningRegistrering(
-            bygningId = 1L,
+            bygningBubbleId = BygningBubbleId(1L),
             bruksenhetRegistreringer = emptyList(),
         ),
     )
@@ -53,7 +61,7 @@ class EgenregistreringValidatorTest {
                 bygningRegistrering = baseEgenregistrering.bygningRegistrering.copy(
                     bruksenhetRegistreringer = listOf(
                         BruksenhetRegistrering(
-                            bruksenhetId = 1L,
+                            bruksenhetBubbleId = BruksenhetBubbleId(1L),
                             bruksarealRegistrering = null,
                             energikildeRegistrering = null,
                             oppvarmingRegistrering = null,
@@ -62,7 +70,7 @@ class EgenregistreringValidatorTest {
                             avlopRegistrering = null,
                         ),
                         BruksenhetRegistrering(
-                            bruksenhetId = 1L,
+                            bruksenhetBubbleId = BruksenhetBubbleId(1L),
                             bruksarealRegistrering = null,
                             energikildeRegistrering = null,
                             oppvarmingRegistrering = null,
@@ -88,7 +96,7 @@ class EgenregistreringValidatorTest {
                 bygningRegistrering = baseEgenregistrering.bygningRegistrering.copy(
                     bruksenhetRegistreringer = listOf(
                         BruksenhetRegistrering(
-                            bruksenhetId = 3L,
+                            bruksenhetBubbleId = BruksenhetBubbleId(3L),
                             bruksarealRegistrering = null,
                             energikildeRegistrering = null,
                             oppvarmingRegistrering = null,
@@ -114,7 +122,7 @@ class EgenregistreringValidatorTest {
                 bygningRegistrering = baseEgenregistrering.bygningRegistrering.copy(
                     bruksenhetRegistreringer = listOf(
                         BruksenhetRegistrering(
-                            bruksenhetId = 1L,
+                            bruksenhetBubbleId = BruksenhetBubbleId(1L),
                             bruksarealRegistrering = BruksarealRegistrering(
                                 totaltBruksareal = 50.0,
                                 etasjeRegistreringer = listOf(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ ktorSwaggerUIVersion = "4.1.6"
 smileySchemaKeneratorVersion = "1.6.4"
 mockOauth2Server = "2.1.10"
 matrikkelWsClientVersion = "4.18.1.0"
+jacksonVersion = "2.18.2"
 
 [libraries]
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core-jvm", version.ref = "ktorVersion" }
@@ -62,6 +63,7 @@ schema-kenerator-core = { group = "io.github.smiley4", name = "schema-kenerator-
 schema-kenerator-reflection = { group = "io.github.smiley4", name = "schema-kenerator-reflection", version.ref = "smileySchemaKeneratorVersion" }
 schema-kenerator-swagger = { group = "io.github.smiley4", name = "schema-kenerator-swagger", version.ref = "smileySchemaKeneratorVersion" }
 
+fasterxml-jackson-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jacksonVersion" }
 [plugins]
 kotlin-jvm = { id = "jvm", version.ref = "kotlinVersion" }
 kotlin-serialization = { id = "plugin.serialization", version.ref = "kotlinVersion" }

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -5,6 +5,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 
 plugins {
     kotlin("jvm")
+
     `jvm-test-suite`
 }
 
@@ -20,7 +21,7 @@ dependencies {
     implementation(libs.hikari)
 
     // Serialization
-    implementation(libs.ktor.serialization.kotlinx)
+    implementation(libs.fasterxml.jackson.kotlin)
 
     // Matrikkel
     implementation(libs.matrikkelapi.ws.client)

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/DatabaseExtensions.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/DatabaseExtensions.kt
@@ -6,6 +6,7 @@ import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Statement
+import java.util.*
 import javax.sql.DataSource
 
 private val log: Logger = LoggerFactory.getLogger(object {}::class.java)
@@ -17,6 +18,13 @@ inline fun <T> Statement.executeQuery(sql: String, block: (ResultSet) -> T) = ex
 
 inline fun <T> Connection.prepareStatement(sql: String, block: (PreparedStatement) -> T) = prepareStatement(sql).use(block)
 inline fun <T> PreparedStatement.executeQuery(block: (ResultSet) -> T) = executeQuery().use(block)
+
+fun PreparedStatement.setUUID(parameterIndex: Int, uuid: UUID) {
+    setObject(
+        parameterIndex,
+        uuid
+    )
+}
 
 fun <T> DataSource.withTransaction(block: (Connection) -> T): T {
     connection.use { connection ->

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/EgenregistreringRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/EgenregistreringRepositoryImpl.kt
@@ -1,44 +1,21 @@
 package no.kartverket.matrikkel.bygning.infrastructure.database.repositories
 
-import kotlinx.serialization.json.Json
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.kartverket.matrikkel.bygning.application.egenregistrering.EgenregistreringRepository
-import no.kartverket.matrikkel.bygning.application.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
-import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.*
-import no.kartverket.matrikkel.bygning.application.models.kodelister.ProsessKode
-import no.kartverket.matrikkel.bygning.infrastructure.database.executeQueryAndMapPreparedStatement
 import no.kartverket.matrikkel.bygning.infrastructure.database.prepareAndExecuteUpdate
+import no.kartverket.matrikkel.bygning.infrastructure.database.setUUID
 import no.kartverket.matrikkel.bygning.infrastructure.database.withTransaction
 import org.postgresql.util.PGobject
 import java.sql.Timestamp
-import java.util.UUID
 import javax.sql.DataSource
 
 class EgenregistreringRepositoryImpl(private val dataSource: DataSource) : EgenregistreringRepository {
-    override fun getAllEgenregistreringerForBygning(bygningId: Long): List<Egenregistrering> {
-        return dataSource.executeQueryAndMapPreparedStatement(
-            """
-                SELECT er.id AS id, 
-                er.eier AS eier, 
-                er.registreringstidspunkt AS registreringstidspunkt, 
-                er.registrering AS bygningregistrering
-                FROM bygning.egenregistrering er
-                WHERE er.registrering ->> 'bygningId' = ?
-                ORDER BY er.registreringstidspunkt DESC;
-            """.trimIndent(),
-            {
-                it.setString(1, bygningId.toString())
-            },
-        ) {
-            Egenregistrering(
-                id = UUID.fromString(it.getString("id")),
-                eier = Foedselsnummer(it.getString("eier")),
-                registreringstidspunkt = it.getTimestamp("registreringstidspunkt").toInstant(),
-                bygningRegistrering = Json.decodeFromString<BygningRegistrering>(it.getString("bygningregistrering")),
-                prosess = ProsessKode.Egenregistrering
-            )
-        }
-    }
+    private val objectMapper = jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     override fun saveEgenregistrering(egenregistrering: Egenregistrering) {
         return dataSource.withTransaction { connection ->
@@ -49,15 +26,14 @@ class EgenregistreringRepositoryImpl(private val dataSource: DataSource) : Egenr
                    VALUES (?, ?, ?, ?)
                 """.trimIndent(),
             ) {
-                it.setObject(1, egenregistrering.id)
+                it.setUUID(1, egenregistrering.id)
                 it.setTimestamp(2, Timestamp.from(egenregistrering.registreringstidspunkt))
                 it.setString(3, egenregistrering.eier.value)
                 it.setObject(
                     4,
                     PGobject().apply {
                         this.type = "jsonb"
-                        // Av en eller annen grunn må jeg eksplisitt nevne serializer typen her
-                        this.value = Json.encodeToString(BygningRegistrering.serializer(), egenregistrering.bygningRegistrering)
+                        this.value = objectMapper.writeValueAsString(egenregistrering.bygningRegistrering)
                     },
                 )
             }

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/bygning/BygningRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/bygning/BygningRepositoryImpl.kt
@@ -1,0 +1,66 @@
+package no.kartverket.matrikkel.bygning.infrastructure.database.repositories.bygning
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.kartverket.matrikkel.bygning.application.bygning.BygningRepository
+import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import no.kartverket.matrikkel.bygning.infrastructure.database.executeQueryAndMapPreparedStatement
+import no.kartverket.matrikkel.bygning.infrastructure.database.prepareAndExecuteUpdate
+import no.kartverket.matrikkel.bygning.infrastructure.database.setUUID
+import no.kartverket.matrikkel.bygning.infrastructure.database.withTransaction
+import org.postgresql.util.PGobject
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.*
+import javax.sql.DataSource
+
+
+class BygningRepositoryImpl(private val dataSource: DataSource) : BygningRepository {
+    private val objectMapper = jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    override fun saveBruksenhet(bruksenhet: Bruksenhet) {
+        return dataSource.withTransaction { connection ->
+            connection.prepareAndExecuteUpdate(
+                """
+                    INSERT INTO bygning.bruksenhet
+                    (id, bruksenhet_bubble_id, bygning_id, registreringstidspunkt, data)
+                    VALUES (?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ) {
+                it.setUUID(1, bruksenhet.id.value)
+                it.setLong(2, bruksenhet.bruksenhetBubbleId.value)
+                it.setUUID(3, bruksenhet.bygningId.value)
+                it.setTimestamp(4, Timestamp.from(Instant.now()))
+                it.setObject(
+                    5,
+                    PGobject().apply {
+                        this.type = "jsonb"
+                        this.value = objectMapper.writeValueAsString(bruksenhet)
+                    },
+                )
+            }
+        }
+    }
+
+    override fun getBruksenhetById(bruksenhetId: UUID): Bruksenhet? {
+        return dataSource.executeQueryAndMapPreparedStatement(
+            """
+                SELECT data
+                FROM bygning.bruksenhet
+                WHERE id = ?
+                ORDER BY registreringstidspunkt DESC
+                LIMIT 1
+            """.trimIndent(),
+            {
+                it.setUUID(1, bruksenhetId)
+            },
+        ) {
+            objectMapper.readValue<Bruksenhet>(it.getString("data"))
+        }.singleOrNull()
+    }
+}
+

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/LocalBygningClient.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/LocalBygningClient.kt
@@ -4,40 +4,47 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.toResultOr
 import no.kartverket.matrikkel.bygning.application.bygning.BygningClient
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
-import no.kartverket.matrikkel.bygning.application.models.BruksenhetId
 import no.kartverket.matrikkel.bygning.application.models.Bygning
-import no.kartverket.matrikkel.bygning.application.models.BygningId
 import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
 import no.kartverket.matrikkel.bygning.application.models.Multikilde
 import no.kartverket.matrikkel.bygning.application.models.RegisterMetadata
 import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Signatur
 import no.kartverket.matrikkel.bygning.application.models.error.BygningNotFound
 import no.kartverket.matrikkel.bygning.application.models.error.DomainError
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningId
 import java.time.Instant
 
 class LocalBygningClient : BygningClient {
     private val bruksenheter: List<Bruksenhet> = listOf(
         Bruksenhet(
-            bruksenhetId = BruksenhetId(1L),
-            bygningId = BygningId(1L),
+            id = BruksenhetId("00000000-0000-0000-0000-000000000001"),
+            bruksenhetBubbleId = BruksenhetBubbleId(1L),
+            bygningId = BygningId("00000000-0000-0000-0000-000000000001"),
         ),
         Bruksenhet(
-            bruksenhetId = BruksenhetId(2L),
-            bygningId = BygningId(1L),
+            id = BruksenhetId("00000000-0000-0000-0000-000000000002"),
+            bruksenhetBubbleId = BruksenhetBubbleId(2L),
+            bygningId = BygningId("00000000-0000-0000-0000-000000000001"),
         ),
         Bruksenhet(
-            bruksenhetId = BruksenhetId(3L),
-            bygningId = BygningId(2L),
+            id = BruksenhetId("00000000-0000-0000-0000-000000000003"),
+            bruksenhetBubbleId = BruksenhetBubbleId(3L),
+            bygningId = BygningId("00000000-0000-0000-0000-000000000002"),
         ),
         Bruksenhet(
-            bruksenhetId = BruksenhetId(4L),
-            bygningId = BygningId(2L),
+            id = BruksenhetId("00000000-0000-0000-0000-000000000004"),
+            bruksenhetBubbleId = BruksenhetBubbleId(4L),
+            bygningId = BygningId("00000000-0000-0000-0000-000000000002"),
         ),
     )
 
     private val bygninger: List<Bygning> = listOf(
         Bygning(
-            bygningId = BygningId(1L),
+            id = BygningId("00000000-0000-0000-0000-000000000001"),
+            bygningBubbleId = BygningBubbleId(1L),
             bygningsnummer = 100L,
             bruksenheter = bruksenheter.subList(0, 2),
             bruksareal = Multikilde(
@@ -47,25 +54,26 @@ class LocalBygningClient : BygningClient {
                         registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
                         registrertAv = Signatur("norola"),
                         kildemateriale = null,
-                        prosess = null
+                        prosess = null,
                     ),
                 ),
             ),
             etasjer = emptyList(),
         ),
         Bygning(
-            bygningId = BygningId(2L),
+            bygningBubbleId = BygningBubbleId(2L),
             bygningsnummer = 200L,
+            id = BygningId("00000000-0000-0000-0000-000000000002"),
             bruksenheter = bruksenheter.subList(2, 4),
             etasjer = emptyList(),
         ),
     )
 
-    override fun getBygningById(id: Long): Result<Bygning, DomainError> {
+    override fun getBygningByBubbleId(bygningBubbleId: Long): Result<Bygning, DomainError> {
         return bygninger
-            .find { it.bygningId.value == id }
+            .find { it.bygningBubbleId.value == bygningBubbleId }
             .toResultOr {
-                BygningNotFound(message = "Bygning med ID $id finnes ikke i matrikkelen")
+                BygningNotFound(message = "Bygning med ID $bygningBubbleId finnes ikke i matrikkelen")
             }
     }
 

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/BygningRepositoryTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/BygningRepositoryTest.kt
@@ -1,0 +1,117 @@
+package no.kartverket.matrikkel.bygning.repositories
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import no.kartverket.matrikkel.bygning.application.models.Felt
+import no.kartverket.matrikkel.bygning.application.models.Multikilde
+import no.kartverket.matrikkel.bygning.application.models.RegisterMetadata
+import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Foedselsnummer
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningId
+import no.kartverket.matrikkel.bygning.application.models.kodelister.AvlopKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.ProsessKode
+import no.kartverket.matrikkel.bygning.infrastructure.database.repositories.bygning.BygningRepositoryImpl
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class BygningRepositoryTest : TestWithDb() {
+    private val bygningRepository = BygningRepositoryImpl(dataSource)
+
+    private val bruksenhetId = BruksenhetId("00000000-0000-0000-0000-000000000001")
+    private val bygningId = BygningId("00000000-0000-0000-0001-000000000001")
+    private val defaultBruksenhet = Bruksenhet(
+        id = bruksenhetId,
+        bruksenhetBubbleId = BruksenhetBubbleId(1L),
+        bygningId = bygningId,
+        avlop = Multikilde(
+            egenregistrert = Felt.Avlop(
+                data = AvlopKode.OffentligKloakk,
+                metadata = RegisterMetadata(
+                    registreringstidspunkt = Instant.now(),
+                    registrertAv = Foedselsnummer("31129956715"),
+                    kildemateriale = KildematerialeKode.Salgsoppgave,
+                    prosess = ProsessKode.Egenregistrering,
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun `lagret bruksenhet skal kunne hentes ut igjen`() {
+        bygningRepository.saveBruksenhet(defaultBruksenhet)
+
+        val retrievedBruksenhet = bygningRepository.getBruksenhetById(defaultBruksenhet.id.value)
+
+
+        assertThat(retrievedBruksenhet).isNotNull().all {
+            prop(Bruksenhet::id).equals(BruksenhetId("00000000-0000-0000-0000-000000000001"))
+            prop(Bruksenhet::bruksenhetBubbleId).equals(BruksenhetBubbleId(1L))
+            prop(Bruksenhet::bygningId).equals(BygningId("00000000-0000-0000-0001-000000000001"))
+            prop(Bruksenhet::avlop).all {
+                prop(Multikilde<Felt.Avlop>::egenregistrert).isNotNull().all {
+                    prop(Felt.Avlop::data).equals(AvlopKode.OffentligKloakk)
+                    prop(Felt.Avlop::metadata).all {
+                        prop(RegisterMetadata::registreringstidspunkt).isNotNull()
+                        prop(RegisterMetadata::registrertAv).equals(Foedselsnummer("31129956715"))
+                        prop(RegisterMetadata::kildemateriale).equals(KildematerialeKode.Salgsoppgave)
+                        prop(RegisterMetadata::prosess).equals(ProsessKode.Egenregistrering)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `lagring av bruksenhet med ny data skal kun hente nyeste versjon`() {
+        bygningRepository.saveBruksenhet(defaultBruksenhet)
+        bygningRepository.saveBruksenhet(defaultBruksenhet.copy(
+            avlop = Multikilde(
+                egenregistrert = Felt.Avlop(
+                    data = AvlopKode.PrivatKloakk,
+                    metadata = RegisterMetadata(
+                        registreringstidspunkt = Instant.now(),
+                        registrertAv = Foedselsnummer("31129956715"),
+                        kildemateriale = KildematerialeKode.Salgsoppgave,
+                        prosess = ProsessKode.Egenregistrering,
+                    ),
+                ),
+            ),
+        ))
+
+        val retrievedBruksenhet = bygningRepository.getBruksenhetById(defaultBruksenhet.id.value)
+
+
+        assertThat(retrievedBruksenhet).isNotNull().all {
+            prop(Bruksenhet::id).equals(BruksenhetId("00000000-0000-0000-0000-000000000001"))
+            prop(Bruksenhet::bruksenhetBubbleId).equals(BruksenhetBubbleId(1L))
+            prop(Bruksenhet::bygningId).equals(BygningId("00000000-0000-0000-0001-000000000001"))
+            prop(Bruksenhet::avlop).all {
+                prop(Multikilde<Felt.Avlop>::egenregistrert).isNotNull().all {
+                    prop(Felt.Avlop::data).equals(AvlopKode.PrivatKloakk)
+                    prop(Felt.Avlop::metadata).all {
+                        prop(RegisterMetadata::registreringstidspunkt).isNotNull()
+                        prop(RegisterMetadata::registrertAv).equals(Foedselsnummer("31129956715"))
+                        prop(RegisterMetadata::kildemateriale).equals(KildematerialeKode.Salgsoppgave)
+                        prop(RegisterMetadata::prosess).equals(ProsessKode.Egenregistrering)
+                    }
+                }
+            }
+        }
+    }
+
+    // Aner ikke om dette er en vettug måte å gjøre dette på? Vi må ha en måte å ha en tom db mellom tester, hvert fall
+    @BeforeEach
+    fun clearBruksenheter() {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute("DELETE FROM bygning.bruksenhet")
+            }
+        }
+    }
+}

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepositoryTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepositoryTest.kt
@@ -1,16 +1,9 @@
 package no.kartverket.matrikkel.bygning.repositories
 
-import assertk.all
-import assertk.assertThat
-import assertk.assertions.hasSize
-import assertk.assertions.index
-import assertk.assertions.isEmpty
-import assertk.assertions.isEqualTo
-import assertk.assertions.prop
-import assertk.assertions.single
 import no.kartverket.matrikkel.bygning.application.models.BygningRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
 import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Foedselsnummer
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningBubbleId
 import no.kartverket.matrikkel.bygning.application.models.kodelister.ProsessKode
 import no.kartverket.matrikkel.bygning.infrastructure.database.repositories.EgenregistreringRepositoryImpl
 import org.junit.jupiter.api.BeforeEach
@@ -22,7 +15,7 @@ class EgenregistreringRepositoryTest : TestWithDb() {
     private val egenregistreringRepository = EgenregistreringRepositoryImpl(dataSource)
 
     private val defaultBygningRegistrering = BygningRegistrering(
-        bygningId = 1L,
+        bygningBubbleId = BygningBubbleId(1L),
         bruksenhetRegistreringer = emptyList()
     )
 
@@ -35,45 +28,8 @@ class EgenregistreringRepositoryTest : TestWithDb() {
     )
 
     @Test
-    fun `lagring av 1 egenregistrering skal kun returnere 1 egenregistrering`() {
+    fun `lagring av gyldig egenregistrering skal ikke feile`() {
         egenregistreringRepository.saveEgenregistrering(defaultEgenregistrering)
-
-        val bygningRegistreringer = egenregistreringRepository.getAllEgenregistreringerForBygning(1L)
-
-        assertThat(bygningRegistreringer).hasSize(1)
-
-        assertThat(bygningRegistreringer).single().all {
-            prop(Egenregistrering::id).isEqualTo(defaultEgenregistrering.id)
-            prop(Egenregistrering::registreringstidspunkt).isEqualTo(defaultEgenregistrering.registreringstidspunkt)
-            prop(Egenregistrering::eier).isEqualTo(defaultEgenregistrering.eier)
-        }
-    }
-
-    @Test
-    fun `lagring av 2 egenregistreringer skal returneres i riktig rekkefolge med seneste registreringer forst i listen`() {
-        val laterRegistrering = defaultEgenregistrering.copy(
-            id = UUID.randomUUID(),
-            registreringstidspunkt = defaultEgenregistrering.registreringstidspunkt.plusSeconds(60)
-        )
-
-        egenregistreringRepository.saveEgenregistrering(defaultEgenregistrering)
-        egenregistreringRepository.saveEgenregistrering(laterRegistrering)
-
-        val registreringer = egenregistreringRepository.getAllEgenregistreringerForBygning(1L)
-
-        assertThat(registreringer).index(0).all {
-            prop(Egenregistrering::id).isEqualTo(laterRegistrering.id)
-        }
-        assertThat(registreringer).index(1).all {
-            prop(Egenregistrering::id).isEqualTo(defaultEgenregistrering.id)
-        }
-    }
-
-    @Test
-    fun `henting av registreringer skal gi tom liste hvis bygningen ikke har registreringer`() {
-        val registreringer = egenregistreringRepository.getAllEgenregistreringerForBygning(1L)
-
-        assertThat(registreringer).isEmpty()
     }
 
     // Aner ikke om dette er en vettug måte å gjøre dette på? Vi må ha en måte å ha en tom db mellom tester, hvert fall

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -18,6 +18,7 @@ import no.kartverket.matrikkel.bygning.infrastructure.database.DatabaseConfig
 import no.kartverket.matrikkel.bygning.infrastructure.database.createDataSource
 import no.kartverket.matrikkel.bygning.infrastructure.database.repositories.EgenregistreringRepositoryImpl
 import no.kartverket.matrikkel.bygning.infrastructure.database.repositories.HealthRepositoryImpl
+import no.kartverket.matrikkel.bygning.infrastructure.database.repositories.bygning.BygningRepositoryImpl
 import no.kartverket.matrikkel.bygning.infrastructure.database.runFlywayMigrations
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.MatrikkelApi
 import no.kartverket.matrikkel.bygning.infrastructure.matrikkel.client.LocalBygningClient
@@ -86,8 +87,17 @@ fun Application.mainModule() {
         }
 
     val egenregistreringRepository = EgenregistreringRepositoryImpl(dataSource)
-    val egenregistreringService = EgenregistreringService(bygningClient, egenregistreringRepository)
-    val bygningService = BygningService(bygningClient, egenregistreringService)
+    val bygningRepository = BygningRepositoryImpl(dataSource)
+
+    val bygningService = BygningService(
+        bygningClient = bygningClient,
+        bygningRepository = bygningRepository,
+    )
+
+    val egenregistreringService = EgenregistreringService(
+        bygningService = bygningService,
+        egenregistreringRepository = egenregistreringRepository,
+    )
 
     routing {
         // Routes for interne endepunkter.

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/bygning/BygningEksternResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/bygning/BygningEksternResponse.kt
@@ -78,7 +78,7 @@ data class RegisterMetadataEksternResponse(
 
 
 fun Bygning.toBygningEksternResponse(): BygningEksternResponse = BygningEksternResponse(
-    bygningId = bygningId.value,
+    bygningId = bygningBubbleId.value,
     bygningsnummer = bygningsnummer,
     bruksenheter = bruksenheter.map {
         it.toBruksenhetEksternResponse()
@@ -103,7 +103,7 @@ private fun <U, T : Felt<U>, O : FeltEksternResponse<U>?> toFeltEksternResponse(
 }
 
 private fun Bruksenhet.toBruksenhetEksternResponse(): BruksenhetEksternResponse = BruksenhetEksternResponse(
-    bruksenhetId = this.bruksenhetId.value,
+    bruksenhetId = this.bruksenhetBubbleId.value,
     byggeaar = toFeltEksternResponse(this.byggeaar.egenregistrert, ::ByggeaarEksternResponse),
     totaltBruksareal = toFeltEksternResponse(this.totaltBruksareal.egenregistrert, ::BruksarealEksternResponse),
     vannforsyning = toFeltEksternResponse(this.vannforsyning.egenregistrert, ::VannforsyningKodeEksternResponse),

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/bygning/BygningEksternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/bygning/BygningEksternRoutes.kt
@@ -37,7 +37,7 @@ fun Route.bygningEksternRouting(
         ) {
             val bygningId = call.parameters.getOrFail("bygningId").toLong()
 
-            val (status, body) = bygningService.getBygningWithEgenregistrertData(bygningId).mapBoth(
+            val (status, body) = bygningService.getBygningByBubbleId(bygningId).mapBoth(
                 success = { HttpStatusCode.OK to it.toBygningEksternResponse() },
                 failure = ::domainErrorToResponse,
             )
@@ -46,3 +46,4 @@ fun Route.bygningEksternRouting(
         }
     }
 }
+

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningResponse.kt
@@ -1,9 +1,23 @@
 package no.kartverket.matrikkel.bygning.routes.v1.intern.bygning
 
 import kotlinx.serialization.Serializable
-import no.kartverket.matrikkel.bygning.application.models.*
-import no.kartverket.matrikkel.bygning.application.models.Felt.*
-import no.kartverket.matrikkel.bygning.application.models.kodelister.*
+import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import no.kartverket.matrikkel.bygning.application.models.Bygning
+import no.kartverket.matrikkel.bygning.application.models.Felt.Avlop
+import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
+import no.kartverket.matrikkel.bygning.application.models.Felt.BruksenhetEtasjer
+import no.kartverket.matrikkel.bygning.application.models.Felt.Byggeaar
+import no.kartverket.matrikkel.bygning.application.models.Felt.Energikilde
+import no.kartverket.matrikkel.bygning.application.models.Felt.Oppvarming
+import no.kartverket.matrikkel.bygning.application.models.Felt.Vannforsyning
+import no.kartverket.matrikkel.bygning.application.models.Multikilde
+import no.kartverket.matrikkel.bygning.application.models.RegisterMetadata
+import no.kartverket.matrikkel.bygning.application.models.kodelister.AvlopKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.OppvarmingKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.ProsessKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.VannforsyningKode
 import no.kartverket.matrikkel.bygning.serializers.InstantSerializer
 import java.time.Instant
 
@@ -118,7 +132,7 @@ fun <T : Any, R : Any> Multikilde<T>.toMultikildeResponse(mapper: T.() -> R): Mu
 }
 
 fun Bygning.toBygningResponse(): BygningResponse = BygningResponse(
-    bygningId = this.bygningId.value,
+    bygningId = this.bygningBubbleId.value,
     bygningsnummer = this.bygningsnummer,
     byggeaar = this.byggeaar.toMultikildeResponse(Byggeaar::toByggeaarResponse),
     bruksareal = this.bruksareal.toMultikildeResponse(Bruksareal::toBruksarealResponse),
@@ -130,13 +144,13 @@ fun Bygning.toBygningResponse(): BygningResponse = BygningResponse(
 )
 
 fun Bygning.toBygningSimpleResponseFromEgenregistrertData(): BygningSimpleResponse = BygningSimpleResponse(
-    bygningId = this.bygningId.value,
+    bygningId = this.bygningBubbleId.value,
     bygningsnummer = this.bygningsnummer,
     bruksenheter = this.bruksenheter.map { it.toBruksenhetSimpleResponseFromEgenregistrertData() },
 )
 
 fun Bruksenhet.toBruksenhetResponse(): BruksenhetResponse = BruksenhetResponse(
-    bruksenhetId = this.bruksenhetId.value,
+    bruksenhetId = this.bruksenhetBubbleId.value,
     byggeaar = this.byggeaar.toMultikildeResponse(Byggeaar::toByggeaarResponse),
     etasjer = this.etasjer.toMultikildeResponse(BruksenhetEtasjer::toBruksenhetEtasjeResponse),
     totaltBruksareal = this.totaltBruksareal.toMultikildeResponse(Bruksareal::toBruksarealResponse),
@@ -147,7 +161,7 @@ fun Bruksenhet.toBruksenhetResponse(): BruksenhetResponse = BruksenhetResponse(
 )
 
 fun Bruksenhet.toBruksenhetSimpleResponseFromEgenregistrertData(): BruksenhetSimpleResponse = BruksenhetSimpleResponse(
-    bruksenhetId = this.bruksenhetId.value,
+    bruksenhetId = this.bruksenhetBubbleId.value,
     byggeaar = this.byggeaar.egenregistrert?.toByggeaarResponse(),
     etasjer = this.etasjer.egenregistrert?.toBruksenhetEtasjeResponse(),
     totaltBruksareal = this.totaltBruksareal.egenregistrert?.toBruksarealResponse(),

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningRoutes.kt
@@ -38,10 +38,11 @@ fun Route.bygningRouting(
         ) {
             val bygningId = call.parameters.getOrFail("bygningId").toLong()
 
-            val (status, body) = bygningService.getBygningWithEgenregistrertData(bygningId).mapBoth(
-                success = { HttpStatusCode.OK to it.toBygningResponse() },
-                failure = ::domainErrorToResponse,
-            )
+            val (status, body) = bygningService.getBygningByBubbleId(bygningBubbleId = bygningId)
+                .mapBoth(
+                    success = { HttpStatusCode.OK to it.toBygningResponse() },
+                    failure = ::domainErrorToResponse,
+                )
 
             call.respond(status, body)
         }
@@ -71,12 +72,13 @@ fun Route.bygningRouting(
             ) {
                 val bygningId = call.parameters.getOrFail("bygningId").toLong()
 
-                val (status, code) = bygningService.getBygningWithEgenregistrertData(bygningId).mapBoth(
-                    success = { (HttpStatusCode.OK to it.toBygningSimpleResponseFromEgenregistrertData()) },
-                    failure = ::domainErrorToResponse,
-                )
+                val (status, body) = bygningService.getBygningByBubbleId(bygningBubbleId = bygningId)
+                    .mapBoth(
+                        success = { HttpStatusCode.OK to it.toBygningSimpleResponseFromEgenregistrertData() },
+                        failure = ::domainErrorToResponse,
+                    )
 
-                call.respond(status, code)
+                call.respond(status, body)
             }
         }
 
@@ -110,7 +112,7 @@ fun Route.bygningRouting(
                     val bygningId = call.parameters.getOrFail("bygningId").toLong()
                     val bruksenhetId = call.parameters.getOrFail("bruksenhetId").toLong()
 
-                    val (status, body) = bygningService.getBruksenhetWithEgenregistrertData(bygningId, bruksenhetId).mapBoth(
+                    val (status, body) = bygningService.getBruksenhetByBubbleId(bygningId, bruksenhetId).mapBoth(
                         success = { HttpStatusCode.OK to it.toBruksenhetResponse() },
                         failure = ::domainErrorToResponse,
                     )
@@ -147,7 +149,7 @@ fun Route.bygningRouting(
                         val bygningId = call.parameters.getOrFail("bygningId").toLong()
                         val bruksenhetId = call.parameters.getOrFail("bruksenhetId").toLong()
 
-                        val (status, body) = bygningService.getBruksenhetWithEgenregistrertData(bygningId, bruksenhetId).mapBoth(
+                        val (status, body) = bygningService.getBruksenhetByBubbleId(bygningId, bruksenhetId).mapBoth(
                             success = { HttpStatusCode.OK to it.toBruksenhetSimpleResponseFromEgenregistrertData() },
                             failure = ::domainErrorToResponse,
                         )

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregistreringRequest.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregistreringRequest.kt
@@ -14,6 +14,8 @@ import no.kartverket.matrikkel.bygning.application.models.Etasjenummer
 import no.kartverket.matrikkel.bygning.application.models.OppvarmingRegistrering
 import no.kartverket.matrikkel.bygning.application.models.RegistreringAktoer.Foedselsnummer
 import no.kartverket.matrikkel.bygning.application.models.VannforsyningRegistrering
+import no.kartverket.matrikkel.bygning.application.models.ids.BruksenhetBubbleId
+import no.kartverket.matrikkel.bygning.application.models.ids.BygningBubbleId
 import no.kartverket.matrikkel.bygning.application.models.kodelister.AvlopKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EtasjeplanKode
@@ -103,7 +105,7 @@ fun EtasjeBruksarealRegistreringRequest.toEtasjeBruksarealRegistrering(): Etasje
 
 fun BruksenhetRegistreringRequest.toBruksenhetRegistrering(): BruksenhetRegistrering {
     return BruksenhetRegistrering(
-        bruksenhetId = bruksenhetId,
+        bruksenhetBubbleId = BruksenhetBubbleId(bruksenhetId),
         bruksarealRegistrering = bruksarealRegistrering?.let { bruksarealRegistrering ->
             BruksarealRegistrering(
                 totaltBruksareal = bruksarealRegistrering.totaltBruksareal,
@@ -146,19 +148,16 @@ fun BruksenhetRegistreringRequest.toBruksenhetRegistrering(): BruksenhetRegistre
     )
 }
 
-fun EgenregistreringRequest.toEgenregistrering(eier: String): Egenregistrering {
-    val registreringstidspunkt = Instant.now()
-
-    return Egenregistrering(
+fun EgenregistreringRequest.toEgenregistrering(eier: String): Egenregistrering =
+    Egenregistrering(
         id = UUID.randomUUID(),
         eier = Foedselsnummer(eier),
-        registreringstidspunkt = registreringstidspunkt,
+        registreringstidspunkt = Instant.now(),
         prosess = ProsessKode.Egenregistrering,
         bygningRegistrering = BygningRegistrering(
-            bygningId = this.bygningId,
+            bygningBubbleId = BygningBubbleId(this.bygningId),
             bruksenhetRegistreringer = this.bruksenhetRegistreringer.map { bruksenhetRegistrering ->
                 bruksenhetRegistrering.toBruksenhetRegistrering()
             },
         ),
     )
-}

--- a/web/src/main/resources/db/migration/V1__init_db.sql
+++ b/web/src/main/resources/db/migration/V1__init_db.sql
@@ -7,3 +7,14 @@ CREATE TABLE egenregistrering
     eier                   VARCHAR(32)              NOT NULL,
     registrering           JSONB                    NOT NULL
 );
+
+
+CREATE TABLE bruksenhet
+(
+    id                     UUID                     NOT NULL,
+    bruksenhet_bubble_id   BIGINT                   NOT NULL,
+    bygning_id             UUID                     NOT NULL,
+    registreringstidspunkt TIMESTAMP WITH TIME ZONE NOT NULL,
+    data                   JSONB                    NOT NULL,
+    PRIMARY KEY (id, registreringstidspunkt)
+);


### PR DESCRIPTION
Endrer med dette oppsettet for hvordan man henter ut bruksenhetsinfo. Tidligere har vi kjørt gjennom alle egenregistreringer ved uthenting, men nå applyer vi kun siste egenregistrering inn til en snapshot av bruksenheten når vi får inn nye egenregistreringer.

Har også gjort at vi bruker UUID internt over boble-IDer, som kan være starten på at vi går over til dette fremfor bobleIDer. Ikke helt sikker på hvordan vi burde håndtere UUIDer i testing, men for nå har jeg bare gått med "tulle"-UUIDer.

I tillegg til dette har jeg satt opp en del Value Classes for IDene, og renamet bobleIDene til å gjenspeile at det er bobleIDer.

Endrer også bruk av kotlinx serialisering i applikasjonsmodulen, da den var litt vel "intrusive" for applikasjonslogikk. Håpet var egentlig å bli kvitt serialiseringsimplementasjoner fullstendig, men på grunn av manglende "hjelp" på hva man deserialiserer av Signatur vs. Fødselsnummer så måtte vi annotere litt der.