### PR TITLE
Spore requests gjennom flere komponenter i loggene

### DIFF
--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/MatrikkelApi.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/MatrikkelApi.kt
@@ -10,6 +10,7 @@ import no.statkart.matrikkel.matrikkelapi.wsapi.v1.service.kommune.KommuneServic
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.service.kommune.KommuneServiceWS
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.service.store.StoreService
 import no.statkart.matrikkel.matrikkelapi.wsapi.v1.service.store.StoreServiceWS
+import org.slf4j.MDC
 import java.net.URI
 
 data class MatrikkelApiConfig(
@@ -51,6 +52,11 @@ class MatrikkelApi(private val baseUrl: URI) {
     private inner class WithAuthImpl(private val authenticator: Authenticator) : WithAuth {
         private fun BindingProvider.configure(endpointPath: String) {
             requestContext[BindingProvider.ENDPOINT_ADDRESS_PROPERTY] = baseUrl.resolve(endpointPath).toString()
+            MDC.get("request_id")?.let {
+                (requestContext.computeIfAbsent(MessageContext.HTTP_REQUEST_HEADERS) { HashMap<String, MutableList<String>>() } as HashMap<String, MutableList<String>>)
+                    .computeIfAbsent("X-Request-ID") { ArrayList<String>() }
+                    .add(it)
+            }
             authenticator(requestContext)
         }
 

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/HTTP.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/HTTP.kt
@@ -42,6 +42,6 @@ fun Application.configureHTTP() {
             call.request.path().startsWith("/v1")
         }
 
-        callIdMdc("call-id")
+        callIdMdc("request_id")
     }
 }

--- a/web/src/main/resources/logback-cloud.xml
+++ b/web/src/main/resources/logback-cloud.xml
@@ -1,6 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %X{request_id} %-5level %logger{36} - %msg%n</pattern>
             <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider"/>
         </encoder>
     </appender>

--- a/web/src/main/resources/logback.xml
+++ b/web/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %X{call-id} %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %X{request_id} %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
     <root level="INFO">


### PR DESCRIPTION
* call_id endres til request_id som gjør det enkelt å f.eks. hente alle logger med en gitt request_id.

* sender med request_id med headere x-request-id slik at vi også kan få inkludert loggene til matrikkelen når vi gjør kall mot den.

* [TB-137](https://kartverket.atlassian.net/browse/TB-137)

[TB-137]: https://kartverket.atlassian.net/browse/TB-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ