### PR TITLE
Fjern null verdier fra innsending av egenregistrering og uthenting av data

### DIFF
--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidator.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidator.kt
@@ -15,7 +15,6 @@ class EgenregistreringValidator {
                 validateBruksenheterRegistreredOnCorrectBygning(egenregistrering, bygning),
                 validateRepeatedBruksenheter(egenregistrering),
             )
-                .plus(validateBruksarealRegistreringerHasTotalBruksareal(egenregistrering))
                 .plus(validateBruksarealRegistreringerTotaltArealIsEqualEtasjerIfExists(egenregistrering))
 
             return if (errors.isEmpty()) {
@@ -69,19 +68,6 @@ class EgenregistreringValidator {
                 .map { invalidRegistrering ->
                     ValidationError(
                         message = "Bruksenhet med ID ${invalidRegistrering.bruksenhetId} har registrert totalt BRA og BRA per etasje, men totalt BRA stemmer ikke overens med totalen av BRA per etasje",
-                    )
-                }
-
-        }
-
-        private fun validateBruksarealRegistreringerHasTotalBruksareal(egenregistrering: Egenregistrering): List<ValidationError> {
-            return egenregistrering.bygningRegistrering.bruksenhetRegistreringer
-                .filter {
-                    it.bruksarealRegistrering?.etasjeRegistreringer != null && it.bruksarealRegistrering.totaltBruksareal == null
-                }
-                .map { invalidRegistrering ->
-                    ValidationError(
-                        message = "Bruksenhet med ID ${invalidRegistrering.bruksenhetId} har registrert BRA per etasje, men ikke totalt BRA. Totalt BRA er obligatorisk.",
                     )
                 }
 

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Bygning.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Bygning.kt
@@ -2,6 +2,7 @@ package no.kartverket.matrikkel.bygning.application.models
 
 import no.kartverket.matrikkel.bygning.application.models.Felt.Avlop
 import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
+import no.kartverket.matrikkel.bygning.application.models.Felt.BruksenhetEtasjer
 import no.kartverket.matrikkel.bygning.application.models.Felt.Byggeaar
 import no.kartverket.matrikkel.bygning.application.models.Felt.Energikilde
 import no.kartverket.matrikkel.bygning.application.models.Felt.Oppvarming
@@ -21,8 +22,8 @@ data class Bygning(
     val bruksenheter: List<Bruksenhet>,
     val byggeaar: Multikilde<Byggeaar> = Multikilde(),
     val bruksareal: Multikilde<Bruksareal> = Multikilde(),
-    val energikilder: Multikilde<List<Energikilde>> = Multikilde(),
-    val oppvarminger: Multikilde<List<Oppvarming>> = Multikilde(),
+    val energikilder: Multikilde<Energikilde> = Multikilde(),
+    val oppvarminger: Multikilde<Oppvarming> = Multikilde(),
     val vannforsyning: Multikilde<Vannforsyning> = Multikilde(),
     val avlop: Multikilde<Avlop> = Multikilde(),
 )
@@ -39,26 +40,27 @@ data class RegisterMetadata(
 )
 
 sealed interface Felt<T> {
-    val data: T?
+    val data: T
     val metadata: RegisterMetadata
 
-    data class Byggeaar(override val data: Int?, override val metadata: RegisterMetadata) : Felt<Int?>
-    data class Vannforsyning(override val data: VannforsyningKode?, override val metadata: RegisterMetadata) : Felt<VannforsyningKode?>
-    data class Bruksareal(override val data: Double?, override val metadata: RegisterMetadata) : Felt<Double?>
-    data class Avlop(override val data: AvlopKode?, override val metadata: RegisterMetadata) : Felt<AvlopKode?>
-    data class Energikilde(override val data: EnergikildeKode, override val metadata: RegisterMetadata) : Felt<EnergikildeKode?>
-    data class Oppvarming(override val data: OppvarmingKode, override val metadata: RegisterMetadata) : Felt<OppvarmingKode?>
+    data class Byggeaar(override val data: Int, override val metadata: RegisterMetadata) : Felt<Int>
+    data class Vannforsyning(override val data: VannforsyningKode, override val metadata: RegisterMetadata) : Felt<VannforsyningKode>
+    data class Bruksareal(override val data: Double, override val metadata: RegisterMetadata) : Felt<Double>
+    data class BruksenhetEtasjer(override val data: List<BruksenhetEtasje>, override val metadata: RegisterMetadata) : Felt<List<BruksenhetEtasje>>
+    data class Avlop(override val data: AvlopKode, override val metadata: RegisterMetadata) : Felt<AvlopKode>
+    data class Energikilde(override val data: List<EnergikildeKode>, override val metadata: RegisterMetadata) : Felt<List<EnergikildeKode>>
+    data class Oppvarming(override val data: List<OppvarmingKode>, override val metadata: RegisterMetadata) : Felt<List<OppvarmingKode>>
 }
 
 
 data class Bruksenhet(
     val bruksenhetId: BruksenhetId,
     val bygningId: BygningId,
-    val etasjer: Multikilde<List<BruksenhetEtasje>> = Multikilde(),
+    val etasjer: Multikilde<BruksenhetEtasjer> = Multikilde(),
     val byggeaar: Multikilde<Byggeaar> = Multikilde(),
     val totaltBruksareal: Multikilde<Bruksareal> = Multikilde(),
-    val energikilder: Multikilde<List<Energikilde>> = Multikilde(),
-    val oppvarminger: Multikilde<List<Oppvarming>> = Multikilde(),
+    val energikilder: Multikilde<Energikilde> = Multikilde(),
+    val oppvarminger: Multikilde<Oppvarming> = Multikilde(),
     val vannforsyning: Multikilde<Vannforsyning> = Multikilde(),
     val avlop: Multikilde<Avlop> = Multikilde(),
 )

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningEgenregistreringAggregering.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningEgenregistreringAggregering.kt
@@ -2,6 +2,7 @@ package no.kartverket.matrikkel.bygning.application.models
 
 import no.kartverket.matrikkel.bygning.application.models.Felt.Avlop
 import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
+import no.kartverket.matrikkel.bygning.application.models.Felt.BruksenhetEtasjer
 import no.kartverket.matrikkel.bygning.application.models.Felt.Byggeaar
 import no.kartverket.matrikkel.bygning.application.models.Felt.Energikilde
 import no.kartverket.matrikkel.bygning.application.models.Felt.Oppvarming
@@ -64,35 +65,31 @@ private fun Bruksenhet.applyEgenregistrering(egenregistrering: Egenregistrering)
             )
         },
         energikilder = this.energikilder.aggregate(bruksenhetRegistrering.energikildeRegistrering) {
-            it.energikilder?.map { registrertKilde ->
-                Energikilde(
-                    data = registrertKilde,
-                    metadata = metadata.withKildemateriale(it.kildemateriale),
-                )
-            }
+            Energikilde(
+                data = it.energikilder,
+                metadata = metadata.withKildemateriale(it.kildemateriale),
+            )
         },
         oppvarminger = this.oppvarminger.aggregate(bruksenhetRegistrering.oppvarmingRegistrering) {
-            it.oppvarminger?.map { registrertOppvarming ->
-                Oppvarming(
-                    data = registrertOppvarming,
-                    metadata = metadata.withKildemateriale(it.kildemateriale),
-                )
-            }
+            Oppvarming(
+                data = it.oppvarminger,
+                metadata = metadata.withKildemateriale(it.kildemateriale),
+            )
         },
 
         etasjer = this.etasjer.aggregate(
             registrering = bruksenhetRegistrering.bruksarealRegistrering?.etasjeRegistreringer,
             shouldMapRegistrering = !this.isEgenregistrertBruksarealRegistreringPresent(),
-        ) {
-            it.map {
-                BruksenhetEtasje(
-                    etasjebetegnelse = it.etasjebetegnelse,
-                    bruksareal = Bruksareal(
-                        data = it.bruksareal,
-                        metadata = metadata.withKildemateriale(bruksenhetRegistrering.bruksarealRegistrering?.kildemateriale),
-                    ),
-                )
-            }
+        ) { etasjeBruksarealRegistreringer ->
+            BruksenhetEtasjer(
+                data = etasjeBruksarealRegistreringer.map {
+                    BruksenhetEtasje(
+                        etasjebetegnelse = it.etasjebetegnelse,
+                        bruksareal = it.bruksareal,
+                    )
+                },
+                metadata = metadata.withKildemateriale(bruksenhetRegistrering.bruksarealRegistrering?.kildemateriale),
+            )
         },
     )
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Egenregistrering.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Egenregistrering.kt
@@ -11,26 +11,24 @@ import no.kartverket.matrikkel.bygning.application.models.kodelister.Vannforsyni
 import java.time.Instant
 import java.util.*
 
-// Er HasKildemateriale det beste navnet her?
 sealed interface HasKildemateriale {
-    // Skal den være nullable?
-    val kildemateriale: KildematerialeKode?
+    val kildemateriale: KildematerialeKode
 }
 
 @Serializable
 data class ByggeaarRegistrering(
-    val byggeaar: Int?,
-    override val kildemateriale: KildematerialeKode?
+    val byggeaar: Int,
+    override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
 @Serializable
 data class BruksarealRegistrering(
-    val totaltBruksareal: Double?,
+    val totaltBruksareal: Double,
     val etasjeRegistreringer: List<EtasjeBruksarealRegistrering>?,
-    override val kildemateriale: KildematerialeKode?
+    override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale {
     fun isTotaltBruksarealEqualTotaltEtasjeArealIfSet(): Boolean {
-        if (totaltBruksareal == null || etasjeRegistreringer == null) {
+        if (etasjeRegistreringer == null) {
             return true
         }
 
@@ -38,38 +36,38 @@ data class BruksarealRegistrering(
     }
 
     fun totaltEtasjeAreal(): Double {
-        return etasjeRegistreringer?.sumOf { it.bruksareal ?: 0.0 } ?: 0.0
+        return etasjeRegistreringer?.sumOf { it.bruksareal } ?: 0.0
     }
 }
 
 @Serializable
 data class EtasjeBruksarealRegistrering(
-    val bruksareal: Double?,
+    val bruksareal: Double,
     val etasjebetegnelse: Etasjebetegnelse,
 )
 
 @Serializable
 data class VannforsyningRegistrering(
-    val vannforsyning: VannforsyningKode?,
-    override val kildemateriale: KildematerialeKode?
+    val vannforsyning: VannforsyningKode,
+    override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
 @Serializable
 data class AvlopRegistrering(
-    val avlop: AvlopKode?,
-    override val kildemateriale: KildematerialeKode?
+    val avlop: AvlopKode,
+    override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
 @Serializable
 data class EnergikildeRegistrering(
-    val energikilder: List<EnergikildeKode>?,
-    override val kildemateriale: KildematerialeKode?
+    val energikilder: List<EnergikildeKode>,
+    override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
 @Serializable
 data class OppvarmingRegistrering(
-    val oppvarminger: List<OppvarmingKode>?,
-    override val kildemateriale: KildematerialeKode?
+    val oppvarminger: List<OppvarmingKode>,
+    override val kildemateriale: KildematerialeKode
 ) : HasKildemateriale
 
 

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Etasje.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Etasje.kt
@@ -1,12 +1,11 @@
 package no.kartverket.matrikkel.bygning.application.models
 
 import kotlinx.serialization.Serializable
-import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EtasjeplanKode
 
 data class BygningEtasje(val etasjebetegnelse: Etasjebetegnelse, val etasjeId: Long)
 
-data class BruksenhetEtasje(val etasjebetegnelse: Etasjebetegnelse, val bruksareal: Bruksareal?)
+data class BruksenhetEtasje(val etasjebetegnelse: Etasjebetegnelse, val bruksareal: Double)
 
 @ConsistentCopyVisibility
 @Serializable

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
@@ -9,7 +9,6 @@ import assertk.assertions.isNull
 import assertk.assertions.prop
 import no.kartverket.matrikkel.bygning.application.models.BruksarealRegistrering
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
-import no.kartverket.matrikkel.bygning.application.models.BruksenhetEtasje
 import no.kartverket.matrikkel.bygning.application.models.BruksenhetId
 import no.kartverket.matrikkel.bygning.application.models.BruksenhetRegistrering
 import no.kartverket.matrikkel.bygning.application.models.ByggeaarRegistrering
@@ -21,6 +20,7 @@ import no.kartverket.matrikkel.bygning.application.models.EtasjeBruksarealRegist
 import no.kartverket.matrikkel.bygning.application.models.Etasjebetegnelse
 import no.kartverket.matrikkel.bygning.application.models.Etasjenummer
 import no.kartverket.matrikkel.bygning.application.models.Felt.Bruksareal
+import no.kartverket.matrikkel.bygning.application.models.Felt.BruksenhetEtasjer
 import no.kartverket.matrikkel.bygning.application.models.Felt.Byggeaar
 import no.kartverket.matrikkel.bygning.application.models.Multikilde
 import no.kartverket.matrikkel.bygning.application.models.RegisterMetadata
@@ -51,7 +51,7 @@ class BygningEgenregistreringAggregeringTest {
         bruksarealRegistrering = BruksarealRegistrering(
             totaltBruksareal = 50.0,
             etasjeRegistreringer = null,
-            kildemateriale = null,
+            kildemateriale = KildematerialeKode.Salgsoppgave,
         ),
         byggeaarRegistrering = null,
         energikildeRegistrering = null,
@@ -197,7 +197,7 @@ class BygningEgenregistreringAggregeringTest {
                                     ),
                                 ),
                             ),
-                            kildemateriale = null,
+                            kildemateriale = KildematerialeKode.Salgsoppgave,
                         ),
 
                         ),
@@ -212,7 +212,7 @@ class BygningEgenregistreringAggregeringTest {
         assertThat(aggregatedBygning).all {
             prop(Bygning::bruksenheter).index(0).all {
                 prop(Bruksenhet::etasjer).all {
-                    prop(Multikilde<List<BruksenhetEtasje>>::egenregistrert).isNull()
+                    prop(Multikilde<BruksenhetEtasjer>::egenregistrert).isNull()
                 }
                 prop(Bruksenhet::totaltBruksareal).all {
                     prop(Multikilde<Bruksareal>::egenregistrert).isNotNull().all {

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
@@ -144,42 +144,4 @@ class EgenregistreringValidatorTest {
         assertThat(validationResult.error.errors).hasSize(1)
         assertThat(validationResult.error.errors.first().message).contains("totalt BRA stemmer ikke overens")
     }
-
-    @Test
-    fun `egenregistrering med registrert etasje BRA men ikke totalt skal feile`() {
-        val validationResult = EgenregistreringValidator.validateEgenregistrering(
-            egenregistrering = baseEgenregistrering.copy(
-                bygningRegistrering = baseEgenregistrering.bygningRegistrering.copy(
-                    bruksenhetRegistreringer = listOf(
-                        BruksenhetRegistrering(
-                            bruksenhetId = 1L,
-                            bruksarealRegistrering = BruksarealRegistrering(
-                                totaltBruksareal = null,
-                                etasjeRegistreringer = listOf(
-                                    EtasjeBruksarealRegistrering(
-                                        bruksareal = 55.0,
-                                        etasjebetegnelse = Etasjebetegnelse.of(
-                                            etasjenummer = Etasjenummer.of(1),
-                                            etasjeplanKode = EtasjeplanKode.Kjelleretasje,
-                                        ),
-                                    ),
-                                ),
-                                kildemateriale = KildematerialeKode.Selvrapportert,
-                            ),
-                            energikildeRegistrering = null,
-                            oppvarmingRegistrering = null,
-                            byggeaarRegistrering = null,
-                            vannforsyningRegistrering = null,
-                            avlopRegistrering = null,
-                        ),
-                    ),
-                ),
-            ),
-            bygning = baseBygning,
-        )
-
-        assertThat(validationResult.isErr).isTrue()
-        assertThat(validationResult.error.errors).hasSize(1)
-        assertThat(validationResult.error.errors.first().message).contains("Totalt BRA er obligatorisk")
-    }
 }

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/MatrikkelBygningClient.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/MatrikkelBygningClient.kt
@@ -85,21 +85,17 @@ class MatrikkelBygningClient(
                     ),
                     // TODO: Skal tom liste i matrikkelen tolkes som "vet ikke" eller "ingen"?
                     energikilder = Multikilde(
-                        autoritativ = bygning.energikildeKodeIds.item.map {
-                            Energikilde(
-                                mapEnergikilde(it),
-                                bygningsmetadata,
-                            )
-                        }.ifEmpty { null }, // Tolker som "vet ikke"
+                        autoritativ = Energikilde(
+                            data = bygning.energikildeKodeIds.item.map { mapEnergikilde(it) },
+                            metadata = bygningsmetadata,
+                        ).takeUnless { bygning.energikildeKodeIds.item.isEmpty() }, // Tolker som "vet ikke"
                     ),
                     // TODO: Skal tom liste i matrikkelen tolkes som "vet ikke" eller "ingen"?
                     oppvarminger = Multikilde(
-                        autoritativ = bygning.oppvarmingsKodeIds.item.map {
-                            Oppvarming(
-                                mapOppvarming(it),
-                                bygningsmetadata,
-                            )
-                        }.ifEmpty { null }, // Tolker som "vet ikke"
+                        autoritativ = Oppvarming(
+                            data = bygning.oppvarmingsKodeIds.item.map { mapOppvarming(it) },
+                            metadata = bygningsmetadata,
+                        ).takeUnless { bygning.oppvarmingsKodeIds.item.isEmpty() } // Tolker som "vet ikke"
                     ),
                     // TODO: Burde vi ha en måte å angi ukjent / ikke oppgitt?
                     bruksenheter = bruksenheter.map {

--- a/infrastructure/src/test/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/MatrikkelBygningClientTest.kt
+++ b/infrastructure/src/test/kotlin/no/kartverket/matrikkel/bygning/infrastructure/matrikkel/client/MatrikkelBygningClientTest.kt
@@ -3,9 +3,7 @@ package no.kartverket.matrikkel.bygning.infrastructure.matrikkel.client
 import assertk.Assert
 import assertk.all
 import assertk.assertThat
-import assertk.assertions.each
-import assertk.assertions.exactly
-import assertk.assertions.hasSize
+import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
@@ -180,22 +178,12 @@ class MatrikkelBygningClientTest {
                 prop(Vannforsyning::metadata).isMatrikkelfoertBygningstidspunkt()
             }
             prop(Bygning::energikilder).erAutoritativIkkeEgenregistrert {
-                hasSize(2)
-                exactly(1) {
-                    it.prop(Energikilde::data).isEqualTo(EnergikildeKode.Elektrisitet)
-                }
-                exactly(1) {
-                    it.prop(Energikilde::data).isEqualTo(EnergikildeKode.Varmepumpe)
-                }
-                each {
-                    it.prop(Energikilde::metadata).isMatrikkelfoertBygningstidspunkt()
-                }
+                prop(Energikilde::data).containsExactly(EnergikildeKode.Elektrisitet, EnergikildeKode.Varmepumpe)
+                prop(Energikilde::metadata).isMatrikkelfoertBygningstidspunkt()
             }
             prop(Bygning::oppvarminger).erAutoritativIkkeEgenregistrert {
-                single().all {
-                    prop(Oppvarming::data).isEqualTo(OppvarmingKode.Elektrisk)
-                    prop(Oppvarming::metadata).isMatrikkelfoertBygningstidspunkt()
-                }
+                prop(Oppvarming::data).containsExactly(OppvarmingKode.Elektrisk)
+                prop(Oppvarming::metadata).isMatrikkelfoertBygningstidspunkt()
             }
             prop(Bygning::bruksenheter).single().all {
                 prop(Bruksenhet::bruksenhetId).isEqualTo(BruksenhetId(2L))

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/EgenregistreringUtils.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/EgenregistreringUtils.kt
@@ -29,7 +29,7 @@ internal fun EgenregistreringRequest.Companion.validEgenregistrering() = Egenreg
             bruksarealRegistrering = BruksarealRegistreringRequest(
                 totaltBruksareal = 125.0,
                 etasjeRegistreringer = null,
-                kildemateriale = null,
+                kildemateriale = KildematerialeKode.Salgsoppgave,
             ),
             byggeaarRegistrering = ByggeaarRegistreringRequest(2010, KildematerialeKode.Selvrapportert),
             vannforsyningRegistrering = VannforsyningRegistreringRequest(
@@ -59,7 +59,7 @@ internal fun EgenregistreringRequest.Companion.ugyldigEgenregistreringMedKunBruk
             bruksenhetId = 1L,
             byggeaarRegistrering = null,
             bruksarealRegistrering = BruksarealRegistreringRequest(
-                totaltBruksareal = null,
+                totaltBruksareal = 50.0,
                 etasjeRegistreringer = listOf(
                     EtasjeBruksarealRegistreringRequest(
                         bruksareal = 125.0,

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningRouteTest.kt
@@ -2,13 +2,13 @@ package no.kartverket.matrikkel.bygning.v1.intern.bygning
 
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.hasSize
 import assertk.assertions.index
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
-import assertk.assertions.single
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -117,12 +117,12 @@ class BygningRouteTest : TestApplicationWithDb() {
                     prop(AvlopKodeResponse::data).isEqualTo(AvlopKode.OffentligKloakk)
                     prop(AvlopKodeResponse::metadata).hasRegistreringstidspunktWithinThreshold(now)
                 }
-                prop(BruksenhetSimpleResponse::oppvarminger).isNotNull().single().all {
-                    prop(OppvarmingResponse::data).isEqualTo(OppvarmingKode.Elektrisk)
+                prop(BruksenhetSimpleResponse::oppvarminger).isNotNull().all {
+                    prop(OppvarmingResponse::data).containsExactly(OppvarmingKode.Elektrisk)
                     prop(OppvarmingResponse::metadata).hasRegistreringstidspunktWithinThreshold(now)
                 }
-                prop(BruksenhetSimpleResponse::energikilder).isNotNull().single().all {
-                    prop(EnergikildeResponse::data).isEqualTo(EnergikildeKode.Elektrisitet)
+                prop(BruksenhetSimpleResponse::energikilder).isNotNull().all {
+                    prop(EnergikildeResponse::data).containsExactly(EnergikildeKode.Elektrisitet)
                     prop(EnergikildeResponse::metadata).hasRegistreringstidspunktWithinThreshold(now)
                 }
             }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
@@ -3,12 +3,12 @@ package no.kartverket.matrikkel.bygning.v1.intern.egenregistrering
 import assertk.Assert
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.index
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
-import assertk.assertions.single
 import assertk.assertions.size
 import assertk.assertions.support.appendName
 import io.ktor.client.call.*
@@ -124,15 +124,15 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
                     }
 
                     prop(BruksenhetResponse::energikilder).isNotNull().all {
-                        prop(MultikildeResponse<List<EnergikildeResponse>>::egenregistrert).isNotNull().single().all {
-                            prop(EnergikildeResponse::data).isEqualTo(EnergikildeKode.Elektrisitet)
+                        prop(MultikildeResponse<EnergikildeResponse>::egenregistrert).isNotNull().all {
+                            prop(EnergikildeResponse::data).containsExactly(EnergikildeKode.Elektrisitet)
                             prop(EnergikildeResponse::metadata).hasRegistreringstidspunktWithinThreshold(now)
                         }
                     }
 
                     prop(BruksenhetResponse::oppvarminger).isNotNull().all {
-                        prop(MultikildeResponse<List<OppvarmingResponse>>::egenregistrert).isNotNull().single().all {
-                            prop(OppvarmingResponse::data).isEqualTo(OppvarmingKode.Elektrisk)
+                        prop(MultikildeResponse<OppvarmingResponse>::egenregistrert).isNotNull().all {
+                            prop(OppvarmingResponse::data).containsExactly(OppvarmingKode.Elektrisk)
                             prop(OppvarmingResponse::metadata).hasRegistreringstidspunktWithinThreshold(now)
                         }
                     }
@@ -181,15 +181,15 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
             }
 
             prop(BruksenhetResponse::energikilder).isNotNull().all {
-                prop(MultikildeResponse<List<EnergikildeResponse>>::egenregistrert).isNotNull().single().all {
-                    prop(EnergikildeResponse::data).isEqualTo(EnergikildeKode.Elektrisitet)
+                prop(MultikildeResponse<EnergikildeResponse>::egenregistrert).isNotNull().all {
+                    prop(EnergikildeResponse::data).containsExactly(EnergikildeKode.Elektrisitet)
                     prop(EnergikildeResponse::metadata).hasRegistreringstidspunktWithinThreshold(now)
                 }
             }
 
             prop(BruksenhetResponse::oppvarminger).isNotNull().all {
-                prop(MultikildeResponse<List<OppvarmingResponse>>::egenregistrert).isNotNull().single().all {
-                    prop(OppvarmingResponse::data).isEqualTo(OppvarmingKode.Elektrisk)
+                prop(MultikildeResponse<OppvarmingResponse>::egenregistrert).isNotNull().all {
+                    prop(OppvarmingResponse::data).containsExactly(OppvarmingKode.Elektrisk)
                     prop(OppvarmingResponse::metadata).hasRegistreringstidspunktWithinThreshold(now)
                 }
             }
@@ -223,7 +223,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
                                 bruksarealRegistrering = BruksarealRegistreringRequest(
                                     totaltBruksareal = 40.0,
                                     etasjeRegistreringer = null,
-                                    kildemateriale = null,
+                                    kildemateriale = KildematerialeKode.Salgsoppgave,
                                 ),
                                 byggeaarRegistrering = ByggeaarRegistreringRequest(
                                     byggeaar = 2008,
@@ -308,7 +308,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
         }
 
     @Test
-    fun `gitt at egenregistrering inneholder kun BRA per etasje og ikke totalt BRA skal man få en bad request i respons`() =
+    fun `gitt at egenregistrering inneholder differanse mellom etasje BRA summert og total BRA kal man få en bad request`() =
         testApplication {
             val client = mainModuleWithDatabaseEnvironmentAndClient()
             val token = mockOAuthServer.issueIDPortenJWT()

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/HTTP.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/HTTP.kt
@@ -12,7 +12,6 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import java.util.*
 
-@OptIn(ExperimentalSerializationApi::class)
 fun Application.configureHTTP() {
     install(ContentNegotiation) {
         json(

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
@@ -14,9 +14,11 @@ import io.github.smiley4.schemakenerator.core.handleNameAnnotation
 import io.github.smiley4.schemakenerator.reflection.collectSubTypes
 import io.github.smiley4.schemakenerator.reflection.processReflection
 import io.github.smiley4.schemakenerator.swagger.compileReferencingRoot
+import io.github.smiley4.schemakenerator.swagger.customizeProperties
 import io.github.smiley4.schemakenerator.swagger.data.TitleType
 import io.github.smiley4.schemakenerator.swagger.generateSwaggerSchema
 import io.github.smiley4.schemakenerator.swagger.handleCoreAnnotations
+import io.github.smiley4.schemakenerator.swagger.handleSchemaAnnotations
 import io.github.smiley4.schemakenerator.swagger.withTitle
 import io.ktor.server.application.*
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.IDPORTEN_PROVIDER_NAME
@@ -60,7 +62,15 @@ private fun PluginConfigDsl.installOpenApiSpec(name: String, title: String, vers
                     .connectSubTypes()
                     .handleNameAnnotation()
                     .generateSwaggerSchema()
+                    // Setter nullable properties til ikke nullable i Swagger skjemaet
+                    // Gjør at vi unngår oneOf(null, type) i generert Swagger skjema.
+                    .customizeProperties { propertyData, propertySchema ->
+                        if (propertyData.nullable) {
+                            propertySchema.nullable = false
+                        }
+                    }
                     .handleCoreAnnotations()
+                    .handleSchemaAnnotations()
                     .withTitle(TitleType.SIMPLE)
                     .compileReferencingRoot()
             }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/bygning/BygningEksternResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/bygning/BygningEksternResponse.kt
@@ -16,7 +16,6 @@ data class BygningEksternResponse(
     val bruksenheter: List<BruksenhetEksternResponse>,
 )
 
-
 @Serializable
 data class BruksenhetEksternResponse(
     val bruksenhetId: Long,
@@ -24,54 +23,49 @@ data class BruksenhetEksternResponse(
     val totaltBruksareal: BruksarealEksternResponse?,
     val vannforsyning: VannforsyningKodeEksternResponse?,
     val avlop: AvlopKodeEksternResponse?,
-    val energikilder: List<EnergikildeEksternResponse>?,
-    val oppvarminger: List<OppvarmingEksternResponse>?,
+    val energikilder: EnergikildeEksternResponse?,
+    val oppvarminger: OppvarmingEksternResponse?,
 )
 
 sealed interface FeltEksternResponse<T> {
-    val data: T?
+    val data: T
     val metadata: RegisterMetadataEksternResponse
 
     @Serializable
     data class ByggeaarEksternResponse(
-        override val data: Int?,
+        override val data: Int,
         override val metadata: RegisterMetadataEksternResponse
-    ) :
-        FeltEksternResponse<Int?>
+    ) : FeltEksternResponse<Int>
 
     @Serializable
     data class BruksarealEksternResponse(
-        override val data: Double?,
+        override val data: Double,
         override val metadata: RegisterMetadataEksternResponse
-    ) :
-        FeltEksternResponse<Double?>
+    ) : FeltEksternResponse<Double>
 
     @Serializable
     data class VannforsyningKodeEksternResponse(
-        override val data: VannforsyningKode?,
+        override val data: VannforsyningKode,
         override val metadata: RegisterMetadataEksternResponse
-    ) : FeltEksternResponse<VannforsyningKode?>
+    ) : FeltEksternResponse<VannforsyningKode>
 
     @Serializable
     data class AvlopKodeEksternResponse(
-        override val data: AvlopKode?,
+        override val data: AvlopKode,
         override val metadata: RegisterMetadataEksternResponse
-    ) :
-        FeltEksternResponse<AvlopKode?>
+    ) : FeltEksternResponse<AvlopKode>
 
     @Serializable
     data class EnergikildeEksternResponse(
-        override val data: EnergikildeKode?,
+        override val data: List<EnergikildeKode>,
         override val metadata: RegisterMetadataEksternResponse
-    ) :
-        FeltEksternResponse<EnergikildeKode?>
+    ) : FeltEksternResponse<List<EnergikildeKode>>
 
     @Serializable
     data class OppvarmingEksternResponse(
-        override val data: OppvarmingKode?,
+        override val data: List<OppvarmingKode>,
         override val metadata: RegisterMetadataEksternResponse
-    ) :
-        FeltEksternResponse<OppvarmingKode>
+    ) : FeltEksternResponse<List<OppvarmingKode>>
 }
 
 
@@ -91,9 +85,9 @@ fun Bygning.toBygningEksternResponse(): BygningEksternResponse = BygningEksternR
     },
 )
 
-private fun <U, T : Felt<U?>, O : FeltEksternResponse<U>?> toFeltEksternResponse(
+private fun <U, T : Felt<U>, O : FeltEksternResponse<U>?> toFeltEksternResponse(
     felt: T?,
-    constructor: (U?, RegisterMetadataEksternResponse) -> O,
+    constructor: (U, RegisterMetadataEksternResponse) -> O,
 ): O? {
     if (felt == null) {
         return null
@@ -114,10 +108,6 @@ private fun Bruksenhet.toBruksenhetEksternResponse(): BruksenhetEksternResponse 
     totaltBruksareal = toFeltEksternResponse(this.totaltBruksareal.egenregistrert, ::BruksarealEksternResponse),
     vannforsyning = toFeltEksternResponse(this.vannforsyning.egenregistrert, ::VannforsyningKodeEksternResponse),
     avlop = toFeltEksternResponse(this.avlop.egenregistrert, ::AvlopKodeEksternResponse),
-    energikilder = this.energikilder.egenregistrert?.mapNotNull { energikilde ->
-        toFeltEksternResponse(energikilde, ::EnergikildeEksternResponse)
-    },
-    oppvarminger = this.oppvarminger.egenregistrert?.mapNotNull { oppvarming ->
-        toFeltEksternResponse(oppvarming, ::OppvarmingEksternResponse)
-    },
+    energikilder = toFeltEksternResponse(this.energikilder.egenregistrert, ::EnergikildeEksternResponse),
+    oppvarminger = toFeltEksternResponse(this.oppvarminger.egenregistrert, ::OppvarmingEksternResponse)
 )

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningResponse.kt
@@ -20,8 +20,8 @@ data class BygningResponse(
     val bruksareal: MultikildeResponse<BruksarealResponse>?,
     val vannforsyning: MultikildeResponse<VannforsyningKodeResponse>?,
     val avlop: MultikildeResponse<AvlopKodeResponse>?,
-    val energikilder: MultikildeResponse<List<EnergikildeResponse>>?,
-    val oppvarming: MultikildeResponse<List<OppvarmingResponse>>?,
+    val energikilder: MultikildeResponse<EnergikildeResponse>?,
+    val oppvarming: MultikildeResponse<OppvarmingResponse>?,
     val bruksenheter: List<BruksenhetResponse>,
 )
 
@@ -33,9 +33,15 @@ data class BygningSimpleResponse(
 )
 
 @Serializable
-    data class BruksenhetEtasjeResponse(
+data class BruksenhetEtasjerResponse(
+    val data: List<BruksenhetEtasjeResponse>,
+    val metadata: RegisterMetadataResponse
+)
+
+@Serializable
+data class BruksenhetEtasjeResponse(
     val etasjebetegnelse: EtasjeBetegnelseResponse,
-    val bruksareal: BruksarealResponse?,
+    val bruksareal: Double,
 )
 
 @Serializable
@@ -47,25 +53,25 @@ data class EtasjeBetegnelseResponse(
 @Serializable
 data class BruksenhetResponse(
     val bruksenhetId: Long,
-    val etasjer: MultikildeResponse<List<BruksenhetEtasjeResponse>>?,
+    val etasjer: MultikildeResponse<BruksenhetEtasjerResponse>?,
     val byggeaar: MultikildeResponse<ByggeaarResponse>?,
     val totaltBruksareal: MultikildeResponse<BruksarealResponse>?,
     val vannforsyning: MultikildeResponse<VannforsyningKodeResponse>?,
     val avlop: MultikildeResponse<AvlopKodeResponse>?,
-    val energikilder: MultikildeResponse<List<EnergikildeResponse>>?,
-    val oppvarminger: MultikildeResponse<List<OppvarmingResponse>>?,
+    val energikilder: MultikildeResponse<EnergikildeResponse>?,
+    val oppvarminger: MultikildeResponse<OppvarmingResponse>?,
 )
 
 @Serializable
 data class BruksenhetSimpleResponse(
     val bruksenhetId: Long,
-    val etasjer: List<BruksenhetEtasjeResponse>?,
+    val etasjer: BruksenhetEtasjerResponse?,
     val byggeaar: ByggeaarResponse?,
     val totaltBruksareal: BruksarealResponse?,
     val vannforsyning: VannforsyningKodeResponse?,
     val avlop: AvlopKodeResponse?,
-    val energikilder: List<EnergikildeResponse>?,
-    val oppvarminger: List<OppvarmingResponse>?,
+    val energikilder: EnergikildeResponse?,
+    val oppvarminger: OppvarmingResponse?,
 )
 
 @Serializable
@@ -73,27 +79,27 @@ data class RegisterMetadataResponse(
     @Serializable(with = InstantSerializer::class)
     val registreringstidspunkt: Instant,
     val registrertAv: String,
-    val kildemateriale: KildematerialeKode? = null,
+    val kildemateriale: KildematerialeKode?,
     val prosess: ProsessKode?
 )
 
 @Serializable
-data class ByggeaarResponse(val data: Int?, val metadata: RegisterMetadataResponse)
+data class ByggeaarResponse(val data: Int, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class BruksarealResponse(val data: Double?, val metadata: RegisterMetadataResponse)
+data class BruksarealResponse(val data: Double, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class VannforsyningKodeResponse(val data: VannforsyningKode?, val metadata: RegisterMetadataResponse)
+data class VannforsyningKodeResponse(val data: VannforsyningKode, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class AvlopKodeResponse(val data: AvlopKode?, val metadata: RegisterMetadataResponse)
+data class AvlopKodeResponse(val data: AvlopKode, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class EnergikildeResponse(val data: EnergikildeKode?, val metadata: RegisterMetadataResponse)
+data class EnergikildeResponse(val data: List<EnergikildeKode>, val metadata: RegisterMetadataResponse)
 
 @Serializable
-data class OppvarmingResponse(val data: OppvarmingKode?, val metadata: RegisterMetadataResponse)
+data class OppvarmingResponse(val data: List<OppvarmingKode>, val metadata: RegisterMetadataResponse)
 
 
 fun RegisterMetadata.toRegisterMetadataResponse() = RegisterMetadataResponse(
@@ -119,8 +125,8 @@ fun Bygning.toBygningResponse(): BygningResponse = BygningResponse(
     bruksenheter = this.bruksenheter.map(Bruksenhet::toBruksenhetResponse),
     vannforsyning = this.vannforsyning.toMultikildeResponse(Vannforsyning::toVannforsyningResponse),
     avlop = this.avlop.toMultikildeResponse(Avlop::toAvlopKodeResponse),
-    energikilder = this.energikilder.toMultikildeResponse { map(Energikilde::toEnergikildeResponse) },
-    oppvarming = this.oppvarminger.toMultikildeResponse { map(Oppvarming::toOppvarmingResponse) },
+    energikilder = this.energikilder.toMultikildeResponse(Energikilde::toEnergikildeResponse),
+    oppvarming = this.oppvarminger.toMultikildeResponse(Oppvarming::toOppvarmingResponse),
 )
 
 fun Bygning.toBygningSimpleResponseFromEgenregistrertData(): BygningSimpleResponse = BygningSimpleResponse(
@@ -132,10 +138,10 @@ fun Bygning.toBygningSimpleResponseFromEgenregistrertData(): BygningSimpleRespon
 fun Bruksenhet.toBruksenhetResponse(): BruksenhetResponse = BruksenhetResponse(
     bruksenhetId = this.bruksenhetId.value,
     byggeaar = this.byggeaar.toMultikildeResponse(Byggeaar::toByggeaarResponse),
-    etasjer = this.etasjer.toMultikildeResponse { map(BruksenhetEtasje::toBruksenhetEtasjeResponse) },
+    etasjer = this.etasjer.toMultikildeResponse(BruksenhetEtasjer::toBruksenhetEtasjeResponse),
     totaltBruksareal = this.totaltBruksareal.toMultikildeResponse(Bruksareal::toBruksarealResponse),
-    energikilder = this.energikilder.toMultikildeResponse { map(Energikilde::toEnergikildeResponse) },
-    oppvarminger = this.oppvarminger.toMultikildeResponse { map(Oppvarming::toOppvarmingResponse) },
+    energikilder = this.energikilder.toMultikildeResponse(Energikilde::toEnergikildeResponse),
+    oppvarminger = this.oppvarminger.toMultikildeResponse(Oppvarming::toOppvarmingResponse),
     vannforsyning = this.vannforsyning.toMultikildeResponse(Vannforsyning::toVannforsyningResponse),
     avlop = this.avlop.toMultikildeResponse(Avlop::toAvlopKodeResponse),
 )
@@ -143,48 +149,53 @@ fun Bruksenhet.toBruksenhetResponse(): BruksenhetResponse = BruksenhetResponse(
 fun Bruksenhet.toBruksenhetSimpleResponseFromEgenregistrertData(): BruksenhetSimpleResponse = BruksenhetSimpleResponse(
     bruksenhetId = this.bruksenhetId.value,
     byggeaar = this.byggeaar.egenregistrert?.toByggeaarResponse(),
-    etasjer = this.etasjer.egenregistrert?.map { it.toBruksenhetEtasjeResponse() },
+    etasjer = this.etasjer.egenregistrert?.toBruksenhetEtasjeResponse(),
     totaltBruksareal = this.totaltBruksareal.egenregistrert?.toBruksarealResponse(),
     vannforsyning = this.vannforsyning.egenregistrert?.toVannforsyningResponse(),
     avlop = this.avlop.egenregistrert?.toAvlopKodeResponse(),
-    energikilder = this.energikilder.egenregistrert?.map { it.toEnergikildeResponse() },
-    oppvarminger = this.oppvarminger.egenregistrert?.map { it.toOppvarmingResponse() },
+    energikilder = this.energikilder.egenregistrert?.toEnergikildeResponse(),
+    oppvarminger = this.oppvarminger.egenregistrert?.toOppvarmingResponse(),
 )
 
-private fun BruksenhetEtasje.toBruksenhetEtasjeResponse(): BruksenhetEtasjeResponse = BruksenhetEtasjeResponse(
-    etasjebetegnelse = EtasjeBetegnelseResponse(
-        etasjeplanKode = etasjebetegnelse.etasjeplanKode.toString(),
-        etasjenummer = etasjebetegnelse.etasjenummer.loepenummer,
-    ),
-    bruksareal = this.bruksareal?.toBruksarealResponse(),
+private fun BruksenhetEtasjer.toBruksenhetEtasjeResponse(): BruksenhetEtasjerResponse = BruksenhetEtasjerResponse(
+    data = this.data.map {
+        BruksenhetEtasjeResponse(
+            bruksareal = it.bruksareal,
+            etasjebetegnelse = EtasjeBetegnelseResponse(
+                etasjeplanKode = it.etasjebetegnelse.etasjeplanKode.toString(),
+                etasjenummer = it.etasjebetegnelse.etasjenummer.loepenummer
+            )
+        )
+    },
+    metadata = this.metadata.toRegisterMetadataResponse()
 )
 
 private fun Byggeaar.toByggeaarResponse(): ByggeaarResponse = ByggeaarResponse(
     data = this.data,
-    metadata = metadata.toRegisterMetadataResponse(),
+    metadata = this.metadata.toRegisterMetadataResponse(),
 )
 
 private fun Bruksareal.toBruksarealResponse(): BruksarealResponse = BruksarealResponse(
     data = this.data,
-    metadata = metadata.toRegisterMetadataResponse(),
+    metadata = this.metadata.toRegisterMetadataResponse(),
 )
 
 private fun Vannforsyning.toVannforsyningResponse(): VannforsyningKodeResponse = VannforsyningKodeResponse(
     data = this.data,
-    metadata = metadata.toRegisterMetadataResponse(),
+    metadata = this.metadata.toRegisterMetadataResponse(),
 )
 
 private fun Avlop.toAvlopKodeResponse(): AvlopKodeResponse = AvlopKodeResponse(
     data = this.data,
-    metadata = metadata.toRegisterMetadataResponse(),
+    metadata = this.metadata.toRegisterMetadataResponse(),
 )
 
 private fun Energikilde.toEnergikildeResponse() = EnergikildeResponse(
     data = this.data,
-    metadata = metadata.toRegisterMetadataResponse(),
+    metadata = this.metadata.toRegisterMetadataResponse(),
 )
 
 private fun Oppvarming.toOppvarmingResponse() = OppvarmingResponse(
     data = this.data,
-    metadata = metadata.toRegisterMetadataResponse(),
+    metadata = this.metadata.toRegisterMetadataResponse(),
 )

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregistreringRequest.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregistreringRequest.kt
@@ -38,13 +38,14 @@ data class BruksenhetRegistreringRequest(
 
 @Serializable
 data class EgenregistreringRequest(
-    val bygningId: Long, val bruksenhetRegistreringer: List<BruksenhetRegistreringRequest>?
+    val bygningId: Long,
+    val bruksenhetRegistreringer: List<BruksenhetRegistreringRequest>
 )
 
 @Serializable
 data class ByggeaarRegistreringRequest(
-    val byggeaar: Int?,
-    val kildemateriale: KildematerialeKode?,
+    val byggeaar: Int,
+    val kildemateriale: KildematerialeKode,
 )
 
 @Serializable
@@ -55,39 +56,39 @@ data class EtasjeBetegnelseRequest(
 
 @Serializable
 data class EtasjeBruksarealRegistreringRequest(
-    val bruksareal: Double?,
+    val bruksareal: Double,
     val etasjebetegnelse: EtasjeBetegnelseRequest,
 )
 
 @Serializable
 data class BruksarealRegistreringRequest(
-    val totaltBruksareal: Double?,
+    val totaltBruksareal: Double,
     val etasjeRegistreringer: List<EtasjeBruksarealRegistreringRequest>?,
-    val kildemateriale: KildematerialeKode?,
+    val kildemateriale: KildematerialeKode,
 )
 
 @Serializable
 data class VannforsyningRegistreringRequest(
-    val vannforsyning: VannforsyningKode?,
-    val kildemateriale: KildematerialeKode?,
+    val vannforsyning: VannforsyningKode,
+    val kildemateriale: KildematerialeKode,
 )
 
 @Serializable
 data class AvlopRegistreringRequest(
-    val avlop: AvlopKode?,
-    val kildemateriale: KildematerialeKode?,
+    val avlop: AvlopKode,
+    val kildemateriale: KildematerialeKode,
 )
 
 @Serializable
 data class EnergikildeRegistreringRequest(
-    val energikilder: List<EnergikildeKode>?,
-    val kildemateriale: KildematerialeKode?,
+    val energikilder: List<EnergikildeKode>,
+    val kildemateriale: KildematerialeKode,
 )
 
 @Serializable
 data class OppvarmingRegistreringRequest(
-    val oppvarminger: List<OppvarmingKode>?,
-    val kildemateriale: KildematerialeKode?,
+    val oppvarminger: List<OppvarmingKode>,
+    val kildemateriale: KildematerialeKode,
 )
 
 fun EtasjeBruksarealRegistreringRequest.toEtasjeBruksarealRegistrering(): EtasjeBruksarealRegistrering {
@@ -103,13 +104,13 @@ fun EtasjeBruksarealRegistreringRequest.toEtasjeBruksarealRegistrering(): Etasje
 fun BruksenhetRegistreringRequest.toBruksenhetRegistrering(): BruksenhetRegistrering {
     return BruksenhetRegistrering(
         bruksenhetId = bruksenhetId,
-        bruksarealRegistrering = bruksarealRegistrering?.let {
+        bruksarealRegistrering = bruksarealRegistrering?.let { bruksarealRegistrering ->
             BruksarealRegistrering(
-                totaltBruksareal = it.totaltBruksareal,
-                etasjeRegistreringer = it.etasjeRegistreringer?.map {
+                totaltBruksareal = bruksarealRegistrering.totaltBruksareal,
+                etasjeRegistreringer = bruksarealRegistrering.etasjeRegistreringer?.map {
                     it.toEtasjeBruksarealRegistrering()
                 },
-                kildemateriale = it.kildemateriale,
+                kildemateriale = bruksarealRegistrering.kildemateriale,
             )
         },
         byggeaarRegistrering = byggeaarRegistrering?.let {
@@ -155,9 +156,9 @@ fun EgenregistreringRequest.toEgenregistrering(eier: String): Egenregistrering {
         prosess = ProsessKode.Egenregistrering,
         bygningRegistrering = BygningRegistrering(
             bygningId = this.bygningId,
-            bruksenhetRegistreringer = this.bruksenhetRegistreringer?.map { bruksenhetRegistrering ->
+            bruksenhetRegistreringer = this.bruksenhetRegistreringer.map { bruksenhetRegistrering ->
                 bruksenhetRegistrering.toBruksenhetRegistrering()
-            } ?: emptyList(),
+            },
         ),
     )
 }


### PR DESCRIPTION
* Flytt metadata for listeverdier (energi og oppvarming) til å være for hele listen med verdier og ikke per felt
* Flytt metadata for bruksareal for etasjer på toppnivå
* Fiks Swagger generering til å unngå oneOf(null, type) for null-properties og bare marker de som ikke required

TB-143