### PR TITLE
TB-140 Legg til nye endepunkter for arkivarisk historikk

### DIFF
--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningRepository.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningRepository.kt
@@ -1,10 +1,11 @@
 package no.kartverket.matrikkel.bygning.application.bygning
 
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import java.time.Instant
 import java.util.*
 
 interface BygningRepository {
     fun saveBruksenhet(bruksenhet: Bruksenhet)
 
-    fun getBruksenhetById(bruksenhetId: UUID): Bruksenhet?
+    fun getBruksenhetById(bruksenhetId: UUID, fremTilDato: Instant): Bruksenhet?
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningService.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningService.kt
@@ -10,22 +10,23 @@ import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
 import no.kartverket.matrikkel.bygning.application.models.applyEgenregistreringer
 import no.kartverket.matrikkel.bygning.application.models.error.BruksenhetNotFound
 import no.kartverket.matrikkel.bygning.application.models.error.DomainError
+import java.time.Instant
 
 class BygningService(
     private val bygningClient: BygningClient,
     private val bygningRepository: BygningRepository,
 ) {
-    fun getBygningByBubbleId(bygningBubbleId: Long): Result<Bygning, DomainError> {
+    fun getBygningByBubbleId(bygningBubbleId: Long, fremTilDato: Instant = Instant.now()): Result<Bygning, DomainError> {
         return bygningClient.getBygningByBubbleId(bygningBubbleId).map { bygning ->
             bygning.copy(
                 bruksenheter = bygning.bruksenheter.map { bruksenhet ->
-                    bygningRepository.getBruksenhetById(bruksenhet.id.value) ?: bruksenhet
+                    bygningRepository.getBruksenhetById(bruksenhet.id.value, fremTilDato) ?: bruksenhet
                 },
             )
         }
     }
 
-    fun getBruksenhetByBubbleId(bygningBubbleId: Long, bruksenhetBubbleId: Long): Result<Bruksenhet, DomainError> {
+    fun getBruksenhetByBubbleId(bygningBubbleId: Long, bruksenhetBubbleId: Long, fremTilDato: Instant = Instant.now()): Result<Bruksenhet, DomainError> {
         return bygningClient.getBygningByBubbleId(bygningBubbleId)
             .andThen { bygning ->
                 bygning.bruksenheter
@@ -35,7 +36,7 @@ class BygningService(
                     }
             }
             .map { bruksenhet ->
-                bygningRepository.getBruksenhetById(bruksenhet.id.value) ?: bruksenhet
+                bygningRepository.getBruksenhetById(bruksenhet.id.value, fremTilDato) ?: bruksenhet
             }
     }
 

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/bygning/BygningRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/bygning/BygningRepositoryImpl.kt
@@ -70,12 +70,13 @@ class BygningRepositoryImpl(private val dataSource: DataSource) : BygningReposit
         }
     }
 
-    override fun getBruksenhetById(id: UUID): Bruksenhet? {
+    override fun getBruksenhetById(id: UUID, fremTilDato: Instant): Bruksenhet? {
         return dataSource.executeQueryAndMapPreparedStatement(
             """
                 SELECT data
                 FROM bygning.bruksenhet
                 WHERE id = ?
+                AND registreringstidspunkt <= ?
                 ORDER BY registreringstidspunkt DESC
                 LIMIT 1
             """.trimIndent(),
@@ -87,6 +88,7 @@ class BygningRepositoryImpl(private val dataSource: DataSource) : BygningReposit
                         this.value = id.toString()
                     },
                 )
+                it.setObject(2, Timestamp.from(fremTilDato))
             },
         ) {
             val bruksenhetDTO = Json.decodeFromString<BruksenhetDTO>(it.getString("data"))

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningRouteTest.kt
@@ -128,6 +128,14 @@ class BygningRouteTest : TestApplicationWithDb() {
             }
         }
     }
+
+    @Test
+    fun `gitt et ugyldig dato query parameter svarer bygning bad request`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val response = client.get("/v1/bygninger/1/egenregistrert/arkiv?dato=UGYLDIG_DATO")
+        assertThat(response.status).isEqualTo(HttpStatusCode.BadRequest)
+    }
 }
 
 


### PR DESCRIPTION
### Bakgrunn
Det må være mulig å hente ut tilstanden for egenregistrerte data for et gitt tidspunkt tilbake i tid. Dette er nødvendig for å støtte egenregistrert data inn i Historisk Matrikkelbrev.

### DRAFT - ønsker om input
Jeg ønsker jeg gjerne input på noen av de større linjene først. Derfor slang jeg opp en kjapp draft. Etter det er litt mer enighet rundt det, skal jeg ofc fikse og rydde litt ☺️ Ønsker spesielt input på: 
- **Nivået endepunktet skal ligge på, og paths:** skal de ligge på et annet nivå i strukturen? Skal "arkiv" komme før eller etter ressursen, skal det være egne frittstående endepunkter eller bare et query parameter på eksisterende? Akkurat nå er det ikke noe ekstra tilgangsstyring på endepunktene, men vi vet på sikt at det vil være et annet tilgangsstyringsnivå for historikk vs nåsituasjonen, så ha det i bakhodet. Det er derfor det ble lagt som eget endepunkt til nå, for å slippe potensielt kluss med tilgangsstyring basert på om brukeren har sendt inn en query param eller ikke. Men veldig åpen for innspill her. 
- **Navnet "arkiv" og "fremTilDato":** dekkende eller har noen bedre forslag? 
- **Gjenbruk av funksjoner i servicelaget:** Jeg har bare gjenbrukt funksjoner og lagt til et nytt parameter "fremTilDato" og satt Instant.now() som default for resterende bruk. Burde det vært splittet opp så man slipper å "sende inn" now for andre endepunkter etc som ikke bryr seg om dato og kun ønsker å hente ut siste versjon? Og holder det å bruke now, eller burde man sette langt i fremtiden?