### PR TITLE
TB-140 Legg til nye endepunkter for arkivarisk historikk

### DIFF
--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningRepository.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningRepository.kt
@@ -1,10 +1,11 @@
 package no.kartverket.matrikkel.bygning.application.bygning
 
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import java.time.Instant
 import java.util.*
 
 interface BygningRepository {
     fun saveBruksenhet(bruksenhet: Bruksenhet)
 
-    fun getBruksenhetById(bruksenhetId: UUID): Bruksenhet?
+    fun getBruksenhetById(bruksenhetId: UUID, registreringstidspunkt: Instant): Bruksenhet?
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningService.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningService.kt
@@ -10,22 +10,27 @@ import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
 import no.kartverket.matrikkel.bygning.application.models.applyEgenregistrering
 import no.kartverket.matrikkel.bygning.application.models.error.BruksenhetNotFound
 import no.kartverket.matrikkel.bygning.application.models.error.DomainError
+import java.time.Instant
 
 class BygningService(
     private val bygningClient: BygningClient,
     private val bygningRepository: BygningRepository,
 ) {
-    fun getBygningByBubbleId(bygningBubbleId: Long): Result<Bygning, DomainError> {
+    fun getBygningByBubbleId(bygningBubbleId: Long, registreringstidspunkt: Instant = Instant.now()): Result<Bygning, DomainError> {
         return bygningClient.getBygningByBubbleId(bygningBubbleId).map { bygning ->
             bygning.copy(
                 bruksenheter = bygning.bruksenheter.map { bruksenhet ->
-                    bygningRepository.getBruksenhetById(bruksenhet.id.value) ?: bruksenhet
+                    bygningRepository.getBruksenhetById(bruksenhet.id.value, registreringstidspunkt) ?: bruksenhet
                 },
             )
         }
     }
 
-    fun getBruksenhetByBubbleId(bygningBubbleId: Long, bruksenhetBubbleId: Long): Result<Bruksenhet, DomainError> {
+    fun getBruksenhetByBubbleId(
+        bygningBubbleId: Long,
+        bruksenhetBubbleId: Long,
+        registreringstidspunkt: Instant = Instant.now()
+    ): Result<Bruksenhet, DomainError> {
         return bygningClient.getBygningByBubbleId(bygningBubbleId)
             .andThen { bygning ->
                 bygning.bruksenheter
@@ -35,7 +40,7 @@ class BygningService(
                     }
             }
             .map { bruksenhet ->
-                bygningRepository.getBruksenhetById(bruksenhet.id.value) ?: bruksenhet
+                bygningRepository.getBruksenhetById(bruksenhet.id.value, registreringstidspunkt) ?: bruksenhet
             }
     }
 

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/bygning/BygningRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/bygning/BygningRepositoryImpl.kt
@@ -46,17 +46,19 @@ class BygningRepositoryImpl(private val dataSource: DataSource) : BygningReposit
         }
     }
 
-    override fun getBruksenhetById(bruksenhetId: UUID): Bruksenhet? {
+    override fun getBruksenhetById(bruksenhetId: UUID, registreringstidspunkt: Instant): Bruksenhet? {
         return dataSource.executeQueryAndMapPreparedStatement(
             """
                 SELECT data
                 FROM bygning.bruksenhet
                 WHERE id = ?
+                AND registreringstidspunkt <= ?
                 ORDER BY registreringstidspunkt DESC
                 LIMIT 1
             """.trimIndent(),
             {
                 it.setUUID(1, bruksenhetId)
+                it.setObject(2, Timestamp.from(registreringstidspunkt))
             },
         ) {
             objectMapper.readValue<Bruksenhet>(it.getString("data"))

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/common/DateTime.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/common/DateTime.kt
@@ -1,0 +1,12 @@
+package no.kartverket.matrikkel.bygning.routes.v1.common
+
+import java.time.Instant
+import java.time.format.DateTimeParseException
+
+fun String.toInstant(): Instant {
+    return try {
+        Instant.parse(this)
+    } catch (e: DateTimeParseException) {
+        throw IllegalArgumentException("Ugyldig datoformat for: '$this'. Forventet format: ISO-8601.", e)
+    }
+}

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/common/ErrorResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/common/ErrorResponse.kt
@@ -23,7 +23,13 @@ fun domainErrorToResponse(error: DomainError): Pair<HttpStatusCode, ErrorRespons
     is BygningNotFound -> HttpStatusCode.NotFound to ErrorResponse.NotFoundError(description = error.message)
     is BruksenhetNotFound -> HttpStatusCode.NotFound to ErrorResponse.NotFoundError(description = error.message)
     is ValidationError -> HttpStatusCode.BadRequest to ErrorResponse.BadRequestError(description = error.message)
-    is MultipleValidationError -> HttpStatusCode.BadRequest to ErrorResponse.ValidationError(details = error.errors.map { ErrorDetailResponse(detail = it.message) })
+    is MultipleValidationError -> HttpStatusCode.BadRequest to ErrorResponse.ValidationError(
+        details = error.errors.map {
+            ErrorDetailResponse(
+                detail = it.message,
+            )
+        },
+    )
 }
 
 @Serializable
@@ -84,5 +90,5 @@ fun ErrorDetail.toErrorDetailResponse(): ErrorDetailResponse {
 }
 
 fun resolveCallID(): String {
-    return MDC.get("call-id") ?: ""
+    return MDC.get("request_id") ?: ""
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/InternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/InternRoutes.kt
@@ -1,10 +1,11 @@
 package no.kartverket.matrikkel.bygning.routes.v1.intern
 
-import io.ktor.server.routing.Route
 import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.ktor.server.routing.*
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
 import no.kartverket.matrikkel.bygning.application.egenregistrering.EgenregistreringService
 import no.kartverket.matrikkel.bygning.plugins.OpenApiSpecIds
+import no.kartverket.matrikkel.bygning.routes.v1.intern.bygning.arkivRouting
 import no.kartverket.matrikkel.bygning.routes.v1.intern.bygning.bygningRouting
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.egenregistreringRouting
 import no.kartverket.matrikkel.bygning.routes.v1.kodeliste.kodelisteRouting
@@ -27,6 +28,9 @@ fun Route.internRouting(
         }
         route("bygninger") {
             bygningRouting(bygningService)
+        }
+        route("arkiv") {
+            arkivRouting(bygningService)
         }
     }
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/ArkivRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/ArkivRoutes.kt
@@ -1,0 +1,121 @@
+package no.kartverket.matrikkel.bygning.routes.v1.intern.bygning
+
+import com.github.michaelbull.result.mapBoth
+import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.util.*
+import no.kartverket.matrikkel.bygning.application.bygning.BygningService
+import no.kartverket.matrikkel.bygning.routes.v1.common.domainErrorToResponse
+import no.kartverket.matrikkel.bygning.routes.v1.common.toInstant
+import java.time.Instant
+
+fun Route.arkivRouting(
+    bygningService: BygningService
+) {
+    route("bygninger") {
+        route("{bygningId}") {
+            route("egenregistrert") {
+                get(
+                    {
+                        summary = "Hent egenregistrert data for en bygning for et gitt registreringstidspunkt"
+                        description =
+                            "Henter tidligere versjon av egenregistrert data for en bygning basert på informasjonsgrunnlaget ved gitt registreringstidspunkt"
+                        request {
+                            pathParameter<String>("bygningId") {
+                                required = true
+                            }
+                            queryParameter<Instant>("registreringstidspunkt") {
+                                description = "Tidspunktet du ønsker å hente data basert på. Format: ISO-8601. Default: nåtidspunkt"
+                            }
+                        }
+                        response {
+                            code(HttpStatusCode.OK) {
+                                body<BygningSimpleResponse> {
+                                    description = "Bygning med én datakilde - kun egenregistrerte data"
+                                }
+                                description = "Bygningen finnes og ble hentet"
+                            }
+                            code(HttpStatusCode.NotFound) {
+                                description = "Fant ikke bygning med gitt bygningId"
+                            }
+                            code(HttpStatusCode.BadRequest) {
+                                description = "Forespørselen inneholder ugyldige parametere. Kontroller at alle felt er korrekt formatert."
+                            }
+                        }
+                    },
+                ) {
+                    val bygningId = call.parameters.getOrFail("bygningId").toLong()
+                    val registreringstidspunkt = call.request.queryParameters["registreringstidspunkt"]?.toInstant() ?: Instant.now()
+
+                    val (status, body) = bygningService.getBygningByBubbleId(
+                        bygningBubbleId = bygningId,
+                        registreringstidspunkt = registreringstidspunkt,
+                    ).mapBoth(
+                        success = { HttpStatusCode.OK to it.toBygningSimpleResponseFromEgenregistrertData() },
+                        failure = ::domainErrorToResponse,
+                    )
+
+                    call.respond(status, body)
+                }
+            }
+
+            route("bruksenheter") {
+                route("{bruksenhetId}") {
+                    route("egenregistrert") {
+                        get(
+                            {
+                                summary = "Hent egenregistrert data for en bruksenhet for et gitt registreringstidspunkt"
+                                description =
+                                    "Henter tidligere versjon av egenregistrert data for en bruksenhet basert på informasjonsgrunnlaget ved gitt registreringstidspunkt"
+                                request {
+                                    pathParameter<String>("bygningId") {
+                                        required = true
+                                    }
+                                    pathParameter<String>("bruksenhetId") {
+                                        required = true
+                                    }
+                                    queryParameter<Instant>("registreringstidspunkt") {
+                                        description = "Tidspunktet du ønsker å hente data basert på. Format: ISO-8601. Default: nåtidspunkt"
+                                    }
+                                }
+                                response {
+                                    code(HttpStatusCode.OK) {
+                                        body<BruksenhetSimpleResponse> {
+                                            description = "Bruksenhet med én datakilde - kun egenregistrerte data"
+                                        }
+                                        description = "Bruksenhet finnes og ble hentet"
+                                    }
+                                    code(HttpStatusCode.NotFound) {
+                                        description = "Fant ikke bruksenhet med gitt bygningId"
+                                    }
+                                    code(HttpStatusCode.BadRequest) {
+                                        description =
+                                            "Forespørselen inneholder ugyldige parametere. Kontroller at alle felt er korrekt formatert."
+                                    }
+                                }
+                            },
+                        ) {
+                            val bygningId = call.parameters.getOrFail("bygningId").toLong()
+                            val bruksenhetId = call.parameters.getOrFail("bruksenhetId").toLong()
+                            val registreringstidspunkt =
+                                call.request.queryParameters["registreringstidspunkt"]?.toInstant() ?: Instant.now()
+
+                            val (status, body) = bygningService.getBruksenhetByBubbleId(
+                                bygningBubbleId = bygningId,
+                                bruksenhetBubbleId = bruksenhetId,
+                                registreringstidspunkt = registreringstidspunkt,
+                            ).mapBoth(
+                                success = { HttpStatusCode.OK to it.toBruksenhetSimpleResponseFromEgenregistrertData() },
+                                failure = ::domainErrorToResponse,
+                            )
+
+                            call.respond(status, body)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningRoutes.kt
@@ -112,7 +112,10 @@ fun Route.bygningRouting(
                     val bygningId = call.parameters.getOrFail("bygningId").toLong()
                     val bruksenhetId = call.parameters.getOrFail("bruksenhetId").toLong()
 
-                    val (status, body) = bygningService.getBruksenhetByBubbleId(bygningId, bruksenhetId).mapBoth(
+                    val (status, body) = bygningService.getBruksenhetByBubbleId(
+                        bygningBubbleId = bygningId,
+                        bruksenhetBubbleId = bruksenhetId,
+                    ).mapBoth(
                         success = { HttpStatusCode.OK to it.toBruksenhetResponse() },
                         failure = ::domainErrorToResponse,
                     )
@@ -149,7 +152,10 @@ fun Route.bygningRouting(
                         val bygningId = call.parameters.getOrFail("bygningId").toLong()
                         val bruksenhetId = call.parameters.getOrFail("bruksenhetId").toLong()
 
-                        val (status, body) = bygningService.getBruksenhetByBubbleId(bygningId, bruksenhetId).mapBoth(
+                        val (status, body) = bygningService.getBruksenhetByBubbleId(
+                            bygningBubbleId = bygningId,
+                            bruksenhetBubbleId = bruksenhetId,
+                        ).mapBoth(
                             success = { HttpStatusCode.OK to it.toBruksenhetSimpleResponseFromEgenregistrertData() },
                             failure = ::domainErrorToResponse,
                         )


### PR DESCRIPTION
Lukket den forrige PRen pga trøbbel med force pushing etc etter at branchen den bygde på ble merget: https://github.com/kartverket/matrikkel-bygning-egenregistrering/pull/214 

### Bakgrunn
Det må være mulig å hente ut tilstanden for egenregistrerte data for et gitt tidspunkt tilbake i tid. Dette er blant annet nødvendig for å støtte egenregistrert data inn i Historisk Matrikkelbrev (lovkrav).

### Endringer 🚀
- **To nye interne endepunkter for uthenting av egenregistrert data basert på registreringstidspunkt**, for henholdvis bygning og bruksenhet. Nytt tillegg på route oppbygningen: `/arkiv?registreringstidspunkt=<datoher>`
- **Gjenbrukt funksjonene i service laget ved å legge til et nytt parameter for registreringstidspunkt** som defaulter til `Instant.now()` - etter samtale med William. I databasen, rent teknisk, henter vi ut materialiseringer frem til og med oppgitt registreringstidspunkt og bruker den nyeste av de. 
- **Lagt til swagger for de nye endepunktene**. Har litt problemer med genereringen av schema type for parameterne, men har en issue hos SMILEY4 her: https://github.com/SMILEY4/ktor-swagger-ui/issues/180. Midlertidig tenkte jeg at vi kanskje kan leve med at det står "null (date-time)", ellers er det jo mulig å midlertidig sette den som` <string>` i swagger doc'en og heller legge inn date-time ellernoe i description🤷‍♀️ Ville ikke bruke for mye tid på det i denne oppgaven for å unngå blokking. 

Har ikke lagt til noe ekstra tilgangsstyring for nå, det får bli en egen oppgave når vi har fått litt mer oversikt over scopet.


### Tips til testing 🧪
- Sjekk at du klarer å hente ut egenregistrert data på både bygning og bruksenhet via de nye endepunktene og med gyldig registreringstidspunkt. 
- Prøv å egenregistrere noe på en bygning eller bruksenhet. Hent ut langt tilbake i tid og sjekk at du ikke får med de nyeste endringene. Hent ut "nå" og sjekk at du får siste endring med. 
- Sjekk at du får 400 bad request dersom du oppgir et ugyldig datoformat.
- Se over swagger doc og sjekk at det ser greit og forståelig ut. Kom gjerne med input på ordlyd som kan gjøre det mer beskrivende. 