### PR TITLE
Lag eget endepunkt for henting av hendelser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ out/
 
 .env
 .DS_Store
+
+.kotlin/

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningRepository.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningRepository.kt
@@ -6,6 +6,6 @@ import java.time.Instant
 import java.util.*
 
 interface BygningRepository {
-    fun saveBruksenheter(bruksenheter: List<Bruksenhet>, tx: TransactionalSession)
+    fun saveBruksenheter(bruksenheter: List<Bruksenhet>, registreringstidspunkt: Instant, tx: TransactionalSession)
     fun getBruksenhetById(bruksenhetId: UUID, registreringstidspunkt: Instant): Bruksenhet?
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningService.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/bygning/BygningService.kt
@@ -6,8 +6,6 @@ import com.github.michaelbull.result.map
 import com.github.michaelbull.result.toResultOr
 import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
 import no.kartverket.matrikkel.bygning.application.models.Bygning
-import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
-import no.kartverket.matrikkel.bygning.application.models.applyEgenregistrering
 import no.kartverket.matrikkel.bygning.application.models.error.BruksenhetNotFound
 import no.kartverket.matrikkel.bygning.application.models.error.DomainError
 import java.time.Instant
@@ -42,12 +40,5 @@ class BygningService(
             .map { bruksenhet ->
                 bygningRepository.getBruksenhetById(bruksenhet.id.value, registreringstidspunkt) ?: bruksenhet
             }
-    }
-
-    fun createSnapshotsOfBruksenheterWithLatestEgenregistrering(bygning: Bygning, egenregistrering: Egenregistrering): List<Bruksenhet> {
-        return egenregistrering.bygningRegistrering.bruksenhetRegistreringer.mapNotNull { bruksenhetRegistrering ->
-            bygning.bruksenheter.find { bruksenhet -> bruksenhet.bruksenhetBubbleId == bruksenhetRegistrering.bruksenhetBubbleId }
-                ?.applyEgenregistrering(egenregistrering)
-        }
     }
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringService.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringService.kt
@@ -5,27 +5,58 @@ import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.map
 import no.kartverket.matrikkel.bygning.application.bygning.BygningRepository
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
+import no.kartverket.matrikkel.bygning.application.hendelser.HendelsePayload.BruksenhetOppdatertPayload
+import no.kartverket.matrikkel.bygning.application.hendelser.HendelseRepository
+import no.kartverket.matrikkel.bygning.application.models.Bruksenhet
+import no.kartverket.matrikkel.bygning.application.models.Bygning
 import no.kartverket.matrikkel.bygning.application.models.Egenregistrering
+import no.kartverket.matrikkel.bygning.application.models.applyEgenregistrering
 import no.kartverket.matrikkel.bygning.application.models.error.DomainError
 import no.kartverket.matrikkel.bygning.application.transaction.Transactional
 
 class EgenregistreringService(
     private val bygningService: BygningService,
     private val egenregistreringRepository: EgenregistreringRepository,
+    private val hendelseRepository: HendelseRepository,
     private val bygningRepository: BygningRepository,
-    private val transactional: Transactional
+    private val transactional: Transactional,
 ) {
     fun addEgenregistrering(egenregistrering: Egenregistrering): Result<Unit, DomainError> {
-        return bygningService.getBygningByBubbleId(egenregistrering.bygningRegistrering.bygningBubbleId.value)
-            .andThen { bygning ->
-                EgenregistreringValidator.validateEgenregistrering(egenregistrering, bygning).map { bygning }
+        return bygningService.getBygningByBubbleId(egenregistrering.bygningRegistrering.bygningBubbleId.value).andThen { bygning ->
+            EgenregistreringValidator.validateEgenregistrering(egenregistrering, bygning).map { bygning }
+        }.map { bygning ->
+            transactional.withTransaction { tx ->
+                egenregistreringRepository.saveEgenregistrering(egenregistrering, tx)
+
+                bygningRepository.saveBruksenheter(
+                    bruksenheter = createBruksenhetSnapshotsOfLatestEgenregistrering(bygning, egenregistrering),
+                    registreringstidspunkt = egenregistrering.registreringstidspunkt,
+                    tx = tx,
+                )
+
+                hendelseRepository.saveHendelser(
+                    payloads = createEgenregistreringHendelsePayloads(egenregistrering),
+                    tx = tx,
+                )
             }
-            .map { bygning ->
-                transactional.withTransaction { tx ->
-                    egenregistreringRepository.saveEgenregistrering(egenregistrering, tx)
-                    bygningService.createSnapshotsOfBruksenheterWithLatestEgenregistrering(bygning, egenregistrering)
-                        .let { bruksenheter -> bygningRepository.saveBruksenheter(bruksenheter, tx) }
-                }
-            }
+        }
+    }
+
+    private fun createBruksenhetSnapshotsOfLatestEgenregistrering(
+        bygning: Bygning, egenregistrering: Egenregistrering
+    ): List<Bruksenhet> {
+        return egenregistrering.bygningRegistrering.bruksenhetRegistreringer.mapNotNull { bruksenhetRegistrering ->
+            bygning.bruksenheter.find { bruksenhet -> bruksenhet.bruksenhetBubbleId == bruksenhetRegistrering.bruksenhetBubbleId }
+                ?.applyEgenregistrering(egenregistrering)
+        }
+    }
+
+    private fun createEgenregistreringHendelsePayloads(egenregistrering: Egenregistrering): List<BruksenhetOppdatertPayload> {
+        return egenregistrering.bygningRegistrering.bruksenhetRegistreringer.map { registrering ->
+            BruksenhetOppdatertPayload(
+                objectId = registrering.bruksenhetBubbleId.value,
+                registreringstidspunkt = egenregistrering.registreringstidspunkt,
+            )
+        }
     }
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/hendelser/HendelseRepository.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/hendelser/HendelseRepository.kt
@@ -1,0 +1,8 @@
+package no.kartverket.matrikkel.bygning.application.hendelser
+
+import kotliquery.TransactionalSession
+
+interface HendelseRepository {
+    fun saveHendelser(payloads: List<HendelsePayload>, tx: TransactionalSession)
+    fun getHendelser(fra: Long, antall: Long) : List<Hendelse>
+}

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/hendelser/HendelseService.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/hendelser/HendelseService.kt
@@ -1,0 +1,9 @@
+package no.kartverket.matrikkel.bygning.application.hendelser
+
+class HendelseService(
+    private val hendelseRepository: HendelseRepository
+) {
+    fun getHendelser(fra: Long, antall: Long): List<Hendelse> {
+        return hendelseRepository.getHendelser(fra, antall)
+    }
+}

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/hendelser/Hendelser.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/hendelser/Hendelser.kt
@@ -1,0 +1,25 @@
+package no.kartverket.matrikkel.bygning.application.hendelser
+
+import java.time.Instant
+
+enum class BygningHendelseType {
+    BRUKSENHET_OPPDATERT,
+}
+
+data class Hendelse(
+    val sekvensnummer: Long,
+    val payload: HendelsePayload
+)
+
+interface HendelsePayload {
+    val objectId: Long
+    val registreringstidspunkt: Instant
+    val type: BygningHendelseType
+
+    data class BruksenhetOppdatertPayload(
+        override val objectId: Long,
+        override val registreringstidspunkt: Instant,
+    ) : HendelsePayload {
+        override val type: BygningHendelseType = BygningHendelseType.BRUKSENHET_OPPDATERT
+    }
+}

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/EgenregistreringRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/EgenregistreringRepositoryImpl.kt
@@ -19,10 +19,10 @@ class EgenregistreringRepositoryImpl : EgenregistreringRepository {
     override fun saveEgenregistrering(egenregistrering: Egenregistrering, tx: TransactionalSession) {
         @Language("PostgreSQL")
         val sql = """
-                   INSERT INTO bygning.egenregistrering
-                   (id, registreringstidspunkt, eier, registrering)
-                   VALUES (:id, :registreringstidspunkt, :eier, :registrering)
-                """
+           INSERT INTO bygning.egenregistrering
+           (id, registreringstidspunkt, eier, registrering)
+           VALUES (:id, :registreringstidspunkt, :eier, :registrering)
+        """.trimIndent()
 
         tx.run(
             queryOf(

--- a/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/HendelseRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/no/kartverket/matrikkel/bygning/infrastructure/database/repositories/HendelseRepositoryImpl.kt
@@ -1,0 +1,78 @@
+package no.kartverket.matrikkel.bygning.infrastructure.database.repositories
+
+import kotliquery.Row
+import kotliquery.TransactionalSession
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import no.kartverket.matrikkel.bygning.application.hendelser.BygningHendelseType
+import no.kartverket.matrikkel.bygning.application.hendelser.Hendelse
+import no.kartverket.matrikkel.bygning.application.hendelser.HendelsePayload
+import no.kartverket.matrikkel.bygning.application.hendelser.HendelsePayload.BruksenhetOppdatertPayload
+import no.kartverket.matrikkel.bygning.application.hendelser.HendelseRepository
+import org.intellij.lang.annotations.Language
+import javax.sql.DataSource
+
+class HendelseRepositoryImpl(private val dataSource: DataSource) : HendelseRepository {
+    override fun saveHendelser(payloads: List<HendelsePayload>, tx: TransactionalSession) {
+        @Language("PostgreSQL")
+        val sql = """
+            INSERT INTO bygning.hendelse (object_id, registreringstidspunkt, type)
+            VALUES(:id, :registreringstidspunkt, :type)
+        """.trimIndent()
+
+        tx.batchPreparedNamedStatement(
+            sql,
+            payloads.map {
+                mapOf(
+                    "id" to it.objectId,
+                    "registreringstidspunkt" to it.registreringstidspunkt,
+                    "type" to it.type.name
+                )
+            },
+        )
+    }
+
+    override fun getHendelser(fra: Long, antall: Long): List<Hendelse> {
+        return sessionOf(dataSource).use {
+            @Language("PostgreSQL")
+            val sql = """
+                SELECT 
+                    sekvensnummer,
+                    object_id,
+                    registreringstidspunkt,
+                    type
+                FROM bygning.hendelse
+                WHERE sekvensnummer >= :fra
+                LIMIT :antall
+            """.trimIndent()
+
+            it.run(
+                queryOf(
+                    sql,
+                    mapOf(
+                        "fra" to fra,
+                        "antall" to antall,
+                    ),
+                ).map { row ->
+                    Hendelse(
+                        sekvensnummer = row.long("sekvensnummer"),
+                        payload = row.toHendelsePayload()
+                    )
+                }.asList,
+            )
+        }
+    }
+
+    private fun Row.toHendelsePayload(): HendelsePayload {
+        return when (val type = string("type")) {
+            BygningHendelseType.BRUKSENHET_OPPDATERT.name -> BruksenhetOppdatertPayload(
+                objectId = long("object_id"),
+                registreringstidspunkt = sqlTimestamp("registreringstidspunkt").toInstant(),
+            )
+
+            else -> {
+                throw IllegalArgumentException("Ukjent hendelsestype: $type")
+            }
+        }
+    }
+}

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/BygningRepositoryTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/BygningRepositoryTest.kt
@@ -27,6 +27,7 @@ class BygningRepositoryTest : TestWithDb() {
 
     private val bruksenhetId = BruksenhetId("00000000-0000-0000-0000-000000000001")
     private val bygningId = BygningId("00000000-0000-0000-0001-000000000001")
+    private val defaultRegistreringstidspunkt = Instant.parse("2025-01-01T00:00:00Z")
     private val defaultBruksenhet = Bruksenhet(
         id = bruksenhetId,
         bruksenhetBubbleId = BruksenhetBubbleId(1L),
@@ -35,7 +36,7 @@ class BygningRepositoryTest : TestWithDb() {
             egenregistrert = Felt.Avlop(
                 data = AvlopKode.OffentligKloakk,
                 metadata = RegisterMetadata(
-                    registreringstidspunkt = Instant.now(),
+                    registreringstidspunkt = defaultRegistreringstidspunkt,
                     registrertAv = Foedselsnummer("31129956715"),
                     kildemateriale = KildematerialeKode.Salgsoppgave,
                     prosess = ProsessKode.Egenregistrering,
@@ -48,6 +49,7 @@ class BygningRepositoryTest : TestWithDb() {
     fun `lagret bruksenhet skal kunne hentes ut igjen`() {
         bygningRepository.saveBruksenheter(
             bruksenheter = listOf(defaultBruksenhet),
+            registreringstidspunkt = defaultRegistreringstidspunkt,
             tx = session
         )
 
@@ -76,6 +78,7 @@ class BygningRepositoryTest : TestWithDb() {
     fun `lagring av bruksenhet med ny data skal kun hente nyeste versjon`() {
         bygningRepository.saveBruksenheter(
             bruksenheter = listOf(defaultBruksenhet),
+            registreringstidspunkt = defaultRegistreringstidspunkt,
             tx = session
         )
         bygningRepository.saveBruksenheter(
@@ -85,7 +88,7 @@ class BygningRepositoryTest : TestWithDb() {
                         egenregistrert = Felt.Avlop(
                             data = AvlopKode.PrivatKloakk,
                             metadata = RegisterMetadata(
-                                registreringstidspunkt = Instant.now(),
+                                registreringstidspunkt = defaultRegistreringstidspunkt.plusSeconds(60),
                                 registrertAv = Foedselsnummer("31129956715"),
                                 kildemateriale = KildematerialeKode.Salgsoppgave,
                                 prosess = ProsessKode.Egenregistrering,
@@ -94,6 +97,7 @@ class BygningRepositoryTest : TestWithDb() {
                     ),
                 ),
             ),
+            registreringstidspunkt = defaultRegistreringstidspunkt.plusSeconds(60),
             tx = session,
         )
 
@@ -123,6 +127,7 @@ class BygningRepositoryTest : TestWithDb() {
 
         bygningRepository.saveBruksenheter(
             bruksenheter = listOf(defaultBruksenhet),
+            registreringstidspunkt = defaultRegistreringstidspunkt,
             tx = session
         )
         bygningRepository.saveBruksenheter(
@@ -132,7 +137,7 @@ class BygningRepositoryTest : TestWithDb() {
                         egenregistrert = Felt.Byggeaar(
                             data = byggeaar,
                             metadata = RegisterMetadata(
-                                registreringstidspunkt = Instant.now(),
+                                registreringstidspunkt = defaultRegistreringstidspunkt.plusSeconds(1),
                                 registrertAv = Foedselsnummer("31129956715"),
                                 kildemateriale = KildematerialeKode.Salgsoppgave,
                                 prosess = ProsessKode.Egenregistrering,
@@ -142,6 +147,7 @@ class BygningRepositoryTest : TestWithDb() {
                     ),
                 ),
             ),
+            registreringstidspunkt = defaultRegistreringstidspunkt.plusSeconds(1),
             tx = session,
         )
 

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/HendelseRepositoryTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/HendelseRepositoryTest.kt
@@ -1,0 +1,57 @@
+package no.kartverket.matrikkel.bygning.repositories
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.each
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import assertk.assertions.size
+import no.kartverket.matrikkel.bygning.application.hendelser.BygningHendelseType
+import no.kartverket.matrikkel.bygning.application.hendelser.Hendelse
+import no.kartverket.matrikkel.bygning.application.hendelser.HendelsePayload
+import no.kartverket.matrikkel.bygning.infrastructure.database.repositories.HendelseRepositoryImpl
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class HendelseRepositoryTest : TestWithDb() {
+    private val hendelseRepositoryTest = HendelseRepositoryImpl(dataSource)
+
+    @Test
+    fun `skal kunne hente ut lagrede hendelser`() {
+        hendelseRepositoryTest.saveHendelser(
+            listOf(
+                HendelsePayload.BruksenhetOppdatertPayload(
+                    objectId = 1L,
+                    registreringstidspunkt = Instant.parse("2025-01-01T12:00:00.00Z"),
+                ),
+                HendelsePayload.BruksenhetOppdatertPayload(
+                    objectId = 2L,
+                    registreringstidspunkt = Instant.parse("2025-01-02T12:00:00.00Z"),
+                ),
+            ),
+            tx = session,
+        )
+
+        val lagredeHendelser = hendelseRepositoryTest.getHendelser(0, 2)
+
+        assertThat(lagredeHendelser).each {
+            it.all {
+                prop(Hendelse::payload).all {
+                    prop(HendelsePayload::type).isEqualTo(BygningHendelseType.BRUKSENHET_OPPDATERT)
+                }
+            }
+        }
+        assertThat(lagredeHendelser).size().isEqualTo(2)
+    }
+
+    // Aner ikke om dette er en vettug måte å gjøre dette på? Vi må ha en måte å ha en tom db mellom tester, hvert fall
+    @BeforeEach
+    fun clearBruksenheter() {
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute("DELETE FROM bygning.hendelse")
+            }
+        }
+    }
+}

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/EgenregistreringUtils.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/EgenregistreringUtils.kt
@@ -21,32 +21,49 @@ import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.Oppvarm
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.VannforsyningRegistreringRequest
 import java.time.Instant
 
+internal fun EgenregistreringRequest.Companion.validBruksenhetRegistreringRequest(bruksenhetId: Long = 1L) = BruksenhetRegistreringRequest(
+    bruksenhetId = bruksenhetId,
+    bruksarealRegistrering = BruksarealRegistreringRequest(
+        totaltBruksareal = 125.0,
+        etasjeRegistreringer = null,
+        kildemateriale = KildematerialeKode.Salgsoppgave,
+    ),
+    byggeaarRegistrering = ByggeaarRegistreringRequest(2010, KildematerialeKode.Selvrapportert),
+    vannforsyningRegistrering = VannforsyningRegistreringRequest(
+        VannforsyningKode.OffentligVannverk,
+        KildematerialeKode.Salgsoppgave,
+    ),
+    avlopRegistrering = AvlopRegistreringRequest(
+        avlop = AvlopKode.OffentligKloakk,
+        KildematerialeKode.Selvrapportert,
+    ),
+    energikildeRegistrering = EnergikildeRegistreringRequest(
+        listOf(EnergikildeKode.Elektrisitet),
+        KildematerialeKode.Selvrapportert,
+    ),
+    oppvarmingRegistrering = OppvarmingRegistreringRequest(
+        listOf(OppvarmingKode.Elektrisk),
+        KildematerialeKode.Selvrapportert,
+    ),
+)
+
 internal fun EgenregistreringRequest.Companion.validEgenregistrering() = EgenregistreringRequest(
     bygningId = 1L,
     bruksenhetRegistreringer = listOf(
-        BruksenhetRegistreringRequest(
-            bruksenhetId = 1L,
-            bruksarealRegistrering = BruksarealRegistreringRequest(
-                totaltBruksareal = 125.0,
-                etasjeRegistreringer = null,
-                kildemateriale = KildematerialeKode.Salgsoppgave,
-            ),
-            byggeaarRegistrering = ByggeaarRegistreringRequest(2010, KildematerialeKode.Selvrapportert),
-            vannforsyningRegistrering = VannforsyningRegistreringRequest(
-                VannforsyningKode.OffentligVannverk,
-                KildematerialeKode.Salgsoppgave,
-            ),
-            avlopRegistrering = AvlopRegistreringRequest(
-                avlop = AvlopKode.OffentligKloakk,
-                KildematerialeKode.Selvrapportert,
-            ),
-            energikildeRegistrering = EnergikildeRegistreringRequest(
-                listOf(EnergikildeKode.Elektrisitet),
-                KildematerialeKode.Selvrapportert,
-            ),
-            oppvarmingRegistrering = OppvarmingRegistreringRequest(
-                listOf(OppvarmingKode.Elektrisk),
-                KildematerialeKode.Selvrapportert,
+        validBruksenhetRegistreringRequest(),
+    ),
+)
+
+internal fun EgenregistreringRequest.Companion.validEgenregistreringMultipleBruksenheter() = EgenregistreringRequest(
+    bygningId = 1L,
+    bruksenhetRegistreringer = listOf(
+        validBruksenhetRegistreringRequest(1L),
+        validBruksenhetRegistreringRequest(2L).copy(
+            energikildeRegistrering = null,
+            oppvarmingRegistrering = null,
+            byggeaarRegistrering = ByggeaarRegistreringRequest(
+                byggeaar = 2008,
+                kildemateriale = KildematerialeKode.Selvrapportert,
             ),
         ),
     ),
@@ -65,9 +82,9 @@ internal fun EgenregistreringRequest.Companion.ugyldigEgenregistreringMedKunBruk
                         bruksareal = 125.0,
                         EtasjeBetegnelseRequest(
                             etasjeplanKode = "H",
-                            etasjenummer = 1
-                        )
-                    )
+                            etasjenummer = 1,
+                        ),
+                    ),
                 ),
                 kildemateriale = KildematerialeKode.Salgsoppgave,
             ),

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/bygning/BygningEksternTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/bygning/BygningEksternTest.kt
@@ -2,16 +2,24 @@ package no.kartverket.matrikkel.bygning.v1.ekstern.bygning
 
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.each
 import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
 import assertk.assertions.prop
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import no.kartverket.matrikkel.bygning.TestApplicationWithDb
+import no.kartverket.matrikkel.bygning.application.hendelser.BygningHendelseType
 import no.kartverket.matrikkel.bygning.routes.v1.ekstern.bygning.BygningEksternResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.hendelse.HendelseContainerResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.hendelse.HendelseResponse
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EgenregistreringRequest
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueIDPortenJWT
 import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueMaskinportenJWT
+import no.kartverket.matrikkel.bygning.v1.common.validEgenregistreringMultipleBruksenheter
 import org.junit.jupiter.api.Test
 
 class BygningEksternTest : TestApplicationWithDb() {
@@ -56,4 +64,46 @@ class BygningEksternTest : TestApplicationWithDb() {
         assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
     }
 
+    @Test
+    fun `gitt at man har egenregistrert på to bruksenheter så skal det være to hendelser i hendelsesloggen`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val idportenJWT = mockOAuthServer.issueIDPortenJWT()
+
+        client.post("/v1/egenregistreringer") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                EgenregistreringRequest.validEgenregistreringMultipleBruksenheter(),
+            )
+            headers {
+                append("Authorization", "Bearer ${idportenJWT.serialize()}")
+            }
+        }
+
+        val maskinportenJWT = mockOAuthServer.issueMaskinportenJWT()
+        val result = client.get("/v1/ekstern/hendelser") {
+            url {
+                parameters.append("antall", "10")
+            }
+            headers {
+                append("Authorization", "Bearer ${maskinportenJWT.serialize()}")
+            }
+        }
+
+        val hendelseContainer = result.body<HendelseContainerResponse>()
+
+        assertThat(hendelseContainer.hendelser).hasSize(2)
+        assertThat(hendelseContainer.hendelser).each {
+            it.all {
+                prop(HendelseResponse::type).isEqualTo(BygningHendelseType.BRUKSENHET_OPPDATERT)
+            }
+        }
+        assertThat(hendelseContainer.hendelser[0]).isNotNull().all {
+            prop(HendelseResponse::objectId).isEqualTo(1L)
+        }
+
+        assertThat(hendelseContainer.hendelser[1]).isNotNull().all {
+            prop(HendelseResponse::objectId).isEqualTo(2L)
+        }
+    }
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/StatusPages.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/StatusPages.kt
@@ -6,7 +6,6 @@ import io.ktor.server.application.*
 import io.ktor.server.plugins.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
-import no.kartverket.matrikkel.bygning.routes.v1.common.ErrorDetailResponse
 import no.kartverket.matrikkel.bygning.routes.v1.common.ErrorResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -24,11 +23,7 @@ fun Application.configureStatusPages() {
                             call.respond(
                                 HttpStatusCode.BadRequest,
                                 ErrorResponse.BadRequestError(
-                                    details = listOf(
-                                        ErrorDetailResponse(
-                                            detail = cause.message ?: "Ukjent feil etter serialisering av request objekt",
-                                        ),
-                                    ),
+                                    cause.message ?: "Ukjent feil etter serialisering av request objekt",
                                 ),
                             )
                         }
@@ -37,12 +32,7 @@ fun Application.configureStatusPages() {
                             call.respond(
                                 HttpStatusCode.BadRequest,
                                 ErrorResponse.BadRequestError(
-                                    details = listOf(
-                                        ErrorDetailResponse(
-                                            detail = exception.message
-                                                ?: "Ukjent feil med request gjør at server ikke kan håndtere forespørselen",
-                                        ),
-                                    ),
+                                    exception.message ?: "Ukjent feil med request gjør at server ikke kan håndtere forespørselen",
                                 ),
                             )
                         }
@@ -55,12 +45,8 @@ fun Application.configureStatusPages() {
                     call.respond(
                         HttpStatusCode.BadRequest,
                         ErrorResponse.BadRequestError(
-                            details = listOf(
-                                ErrorDetailResponse(
-                                    detail = exception.message ?: "Et eller flere felter i requesten var ugyldig"
-                                )
-                            )
-                        )
+                            exception.message ?: "Et eller flere felter i requesten var ugyldig",
+                        ),
                     )
                 }
 

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/EksternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/EksternRoutes.kt
@@ -5,12 +5,15 @@ import io.ktor.http.*
 import io.ktor.server.auth.*
 import io.ktor.server.routing.*
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
+import no.kartverket.matrikkel.bygning.application.hendelser.HendelseService
 import no.kartverket.matrikkel.bygning.plugins.OpenApiSpecIds
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.MASKINPORTEN_PROVIDER_NAME
 import no.kartverket.matrikkel.bygning.routes.v1.ekstern.bygning.bygningEksternRouting
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.hendelse.hendelseEksternRouting
 
 fun Route.eksternRouting(
     bygningService: BygningService,
+    hendelseService: HendelseService,
 ) {
     authenticate(MASKINPORTEN_PROVIDER_NAME) {
         route(
@@ -27,6 +30,10 @@ fun Route.eksternRouting(
         ) {
             route("bygninger") {
                 bygningEksternRouting(bygningService)
+            }
+
+            route("hendelser") {
+                hendelseEksternRouting(hendelseService)
             }
         }
     }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/hendelse/HendelseEksternResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/hendelse/HendelseEksternResponse.kt
@@ -1,0 +1,34 @@
+package no.kartverket.matrikkel.bygning.routes.v1.ekstern.hendelse
+
+import kotlinx.serialization.Serializable
+import no.kartverket.matrikkel.bygning.application.hendelser.BygningHendelseType
+import no.kartverket.matrikkel.bygning.application.hendelser.Hendelse
+import no.kartverket.matrikkel.bygning.serializers.InstantSerializer
+import java.time.Instant
+
+@Serializable
+data class HendelseResponse(
+    val sekvensnummer: Long,
+    val objectId: Long,
+    @Serializable(with = InstantSerializer::class)
+    val registreringstidspunkt: Instant,
+    val type: BygningHendelseType
+)
+
+@Serializable
+data class HendelseContainerResponse(
+    val hendelser: List<HendelseResponse>,
+)
+
+fun List<Hendelse>.toHendelseContainerResponse(): HendelseContainerResponse {
+    return HendelseContainerResponse(
+        hendelser = this.map { hendelse ->
+            HendelseResponse(
+                sekvensnummer = hendelse.sekvensnummer,
+                objectId = hendelse.payload.objectId,
+                registreringstidspunkt = hendelse.payload.registreringstidspunkt,
+                type = hendelse.payload.type,
+            )
+        },
+    )
+}

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/hendelse/HendelseEksternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/hendelse/HendelseEksternRoutes.kt
@@ -1,0 +1,84 @@
+package no.kartverket.matrikkel.bygning.routes.v1.ekstern.hendelse
+
+import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.ktor.http.*
+import io.ktor.server.plugins.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.kartverket.matrikkel.bygning.application.hendelser.HendelseService
+import no.kartverket.matrikkel.bygning.routes.v1.common.ErrorResponse
+
+object HendelseRoutingConstants {
+    const val FRA_QUERY_PARAM = "fra"
+    const val FRA_QUERY_PARAM_DEFAULT: Long = 1
+    const val ANTALL_QUERY_PARAM = "antall"
+    const val ANTALL_QUERY_PARAM_MAX: Long = 1000
+}
+
+fun Route.hendelseEksternRouting(
+    hendelseService: HendelseService
+) {
+    get(
+        {
+            summary = "Henter hendelser som har skjedd"
+            description =
+                "Henter en liste med hendelser som har skjedd i systemet gitt et fra-sekvensnummer og et antall"
+            request {
+                queryParameter<Long>(HendelseRoutingConstants.FRA_QUERY_PARAM) {
+                    required = false
+                    description = "Sekvensnummeret som det skal hentes fra, inklusivt med default = 1"
+                }
+                queryParameter<Long>(HendelseRoutingConstants.ANTALL_QUERY_PARAM) {
+                    required = true
+                    description =
+                        "Antall hendelser som skal hentes. Maks antall som hentes er satt til ${HendelseRoutingConstants.ANTALL_QUERY_PARAM_MAX} hendelser." +
+                                "Påkrevd felt, da vi ønsker at man har tatt stilling til behov for datamengde."
+                }
+            }
+
+            response {
+                code(HttpStatusCode.OK) {
+                    body<HendelseContainerResponse> {
+                        description = "Hendelsene som er innenfor antall og fra-sekvensnummer"
+                    }
+                    description = "Alle parametre var gyldig og hendelsene ble hentet"
+                }
+                code(HttpStatusCode.BadRequest) {
+                    body<ErrorResponse.BadRequestError> {}
+                    description = "Ugyldige parametre for henting av hendelser"
+                }
+            }
+        },
+    ) {
+        val hendelserQueryParams = call.getHendelserQuery()
+
+        val hendelser = hendelseService.getHendelser(
+            fra = hendelserQueryParams.fra,
+            antall = hendelserQueryParams.antall,
+        )
+
+        call.respond(HttpStatusCode.OK, hendelser.toHendelseContainerResponse())
+    }
+}
+
+class HendelserQuery private constructor(val fra: Long, val antall: Long) {
+    companion object {
+        fun of(fra: Long, antall: Long?): HendelserQuery {
+            if (antall == null) {
+                throw BadRequestException("Ugyldige parametre for henting av hendelser. Antall må være definert")
+            }
+            if (fra <= 0L || antall <= 0L) {
+                throw BadRequestException("Ugyldige parametre for henting av hendelser. Både fra og antall må være større enn 0")
+            }
+            return HendelserQuery(fra, minOf(antall, HendelseRoutingConstants.ANTALL_QUERY_PARAM_MAX))
+        }
+    }
+}
+
+private fun RoutingCall.getHendelserQuery(): HendelserQuery {
+    return HendelserQuery.of(
+        fra = parameters[HendelseRoutingConstants.FRA_QUERY_PARAM]?.toLong()
+            ?: HendelseRoutingConstants.FRA_QUERY_PARAM_DEFAULT,
+        antall = parameters[HendelseRoutingConstants.ANTALL_QUERY_PARAM]?.toLong()
+    )
+}

--- a/web/src/main/resources/db/migration/V1__init_db.sql
+++ b/web/src/main/resources/db/migration/V1__init_db.sql
@@ -18,3 +18,11 @@ CREATE TABLE bruksenhet
     data                   JSONB                    NOT NULL,
     PRIMARY KEY (id, registreringstidspunkt)
 );
+
+CREATE TABLE hendelse
+(
+    sekvensnummer          BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    registreringstidspunkt TIMESTAMP WITH TIME ZONE NOT NULL,
+    object_id              BIGINT                   NOT NULL,
+    type                   VARCHAR(32)              NOT NULL
+);


### PR DESCRIPTION
Per nå er det kun lagring av egenregistreringer som forårsaker en hendelse, men oppsettet er generelt nok til at det skal kunne tåle flere typer hendelser fremover, som kunne vært hensiktsmessig å prøve ut.

Ting er forsøkt holdt ganske enkelt i første omgang så ting er lettere å forholde seg til. På sikt så vil det nok være ønskelig å få bedre oversikt over "hva skjedde ved x hendelse", som man ikke får i noen stor grad nå.