### PR TITLE
Forenkling av logback-cloud.xml

### DIFF
--- a/web/src/main/resources/logback-cloud.xml
+++ b/web/src/main/resources/logback-cloud.xml
@@ -1,13 +1,8 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %X{request_id} %-5level %logger{36} - %msg%n</pattern>
-            <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider"/>
-        </encoder>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.eclipse.jetty" level="INFO"/>
-    <logger name="io.netty" level="INFO"/>
 </configuration>


### PR DESCRIPTION
* pattern blir ikke hensyntatt når man benytter LogstashEncoder
* Vi benytter ikke såkalte StructuredArguments per nå så ArgumentsJsonProvider har ingen effekt. Fjerner derfor denne