### PR TITLE
Krev Entra JWT token med custom rolle for å hente ut arkivarisk historikk

### DIFF
--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
@@ -74,7 +74,7 @@ class BygningEgenregistreringAggregeringTest {
     private val defaultEgenregistrering = Egenregistrering(
         id = UUID.randomUUID(),
         registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
-        eier = Foedselsnummer("31129956715"),
+        eier = Foedselsnummer("66860475309"),
         bygningRegistrering = defaultBygningRegistrering,
         prosess = ProsessKode.Egenregistrering,
     )

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/RegistreringAktoerTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/RegistreringAktoerTest.kt
@@ -25,6 +25,6 @@ class RegistreringAktoerTest {
 
     @Test
     fun `fnr med riktig lengde og oppbyggning skal valideres`() {
-        assertThat(Foedselsnummer("31129956715").value).isEqualTo("31129956715")
+        assertThat(Foedselsnummer("66860475309").value).isEqualTo("66860475309")
     }
 }

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/egenregistrering/EgenregistreringValidatorTest.kt
@@ -46,7 +46,7 @@ class EgenregistreringValidatorTest {
     private val baseEgenregistrering = Egenregistrering(
         id = UUID.randomUUID(),
         registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
-        eier = Foedselsnummer("31129956715"),
+        eier = Foedselsnummer("66860475309"),
         prosess = ProsessKode.Egenregistrering,
         bygningRegistrering = BygningRegistrering(
             bygningBubbleId = BygningBubbleId(1L),

--- a/infrastructure/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/BygningRepositoryTest.kt
+++ b/infrastructure/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/BygningRepositoryTest.kt
@@ -37,7 +37,7 @@ class BygningRepositoryTest : TestWithDb() {
                 data = AvlopKode.OffentligKloakk,
                 metadata = RegisterMetadata(
                     registreringstidspunkt = defaultRegistreringstidspunkt,
-                    registrertAv = Foedselsnummer("31129956715"),
+                    registrertAv = Foedselsnummer("66860475309"),
                     kildemateriale = KildematerialeKode.Salgsoppgave,
                     prosess = ProsessKode.Egenregistrering,
                 ),
@@ -65,7 +65,7 @@ class BygningRepositoryTest : TestWithDb() {
                     prop(Felt.Avlop::data).isEqualTo(AvlopKode.OffentligKloakk)
                     prop(Felt.Avlop::metadata).all {
                         prop(RegisterMetadata::registreringstidspunkt).isNotNull()
-                        prop(RegisterMetadata::registrertAv).isEqualTo(Foedselsnummer("31129956715"))
+                        prop(RegisterMetadata::registrertAv).isEqualTo(Foedselsnummer("66860475309"))
                         prop(RegisterMetadata::kildemateriale).isEqualTo(KildematerialeKode.Salgsoppgave)
                         prop(RegisterMetadata::prosess).isEqualTo(ProsessKode.Egenregistrering)
                     }
@@ -89,7 +89,7 @@ class BygningRepositoryTest : TestWithDb() {
                             data = AvlopKode.PrivatKloakk,
                             metadata = RegisterMetadata(
                                 registreringstidspunkt = defaultRegistreringstidspunkt.plusSeconds(60),
-                                registrertAv = Foedselsnummer("31129956715"),
+                                registrertAv = Foedselsnummer("66860475309"),
                                 kildemateriale = KildematerialeKode.Salgsoppgave,
                                 prosess = ProsessKode.Egenregistrering,
                             ),
@@ -112,7 +112,7 @@ class BygningRepositoryTest : TestWithDb() {
                     prop(Felt.Avlop::data).isEqualTo(AvlopKode.PrivatKloakk)
                     prop(Felt.Avlop::metadata).all {
                         prop(RegisterMetadata::registreringstidspunkt).isNotNull()
-                        prop(RegisterMetadata::registrertAv).isEqualTo(Foedselsnummer("31129956715"))
+                        prop(RegisterMetadata::registrertAv).isEqualTo(Foedselsnummer("66860475309"))
                         prop(RegisterMetadata::kildemateriale).isEqualTo(KildematerialeKode.Salgsoppgave)
                         prop(RegisterMetadata::prosess).isEqualTo(ProsessKode.Egenregistrering)
                     }
@@ -138,7 +138,7 @@ class BygningRepositoryTest : TestWithDb() {
                             data = byggeaar,
                             metadata = RegisterMetadata(
                                 registreringstidspunkt = defaultRegistreringstidspunkt.plusSeconds(1),
-                                registrertAv = Foedselsnummer("31129956715"),
+                                registrertAv = Foedselsnummer("66860475309"),
                                 kildemateriale = KildematerialeKode.Salgsoppgave,
                                 prosess = ProsessKode.Egenregistrering,
 

--- a/infrastructure/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepositoryTest.kt
+++ b/infrastructure/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/repositories/EgenregistreringRepositoryTest.kt
@@ -22,7 +22,7 @@ class EgenregistreringRepositoryTest : TestWithDb() {
     private val defaultEgenregistrering = Egenregistrering(
         id = UUID.randomUUID(),
         registreringstidspunkt = Instant.parse("2024-01-01T12:00:00.00Z"),
-        eier = Foedselsnummer("31129956715"),
+        eier = Foedselsnummer("66860475309"),
         bygningRegistrering = defaultBygningRegistrering,
         prosess = ProsessKode.Egenregistrering
     )

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/TestApplicationWithDb.kt
@@ -6,6 +6,8 @@ import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.config.*
 import io.ktor.server.testing.*
 import kotlinx.serialization.json.Json
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.DEFAULT_AUDIENCE
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.DEFAULT_ISSUER
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -67,13 +69,17 @@ abstract class TestApplicationWithDb {
                     "storage.username" to postgresSQLContainer.username,
                     "storage.password" to postgresSQLContainer.password,
                     "matrikkel.useStub" to "true",
-                    "maskinporten.issuer" to mockOAuthServer.issuerUrl("testIssuer").toString(),
-                    "maskinporten.jwksUri" to mockOAuthServer.jwksUrl("testIssuer").toString(),
+                    "maskinporten.issuer" to mockOAuthServer.issuerUrl(DEFAULT_ISSUER).toString(),
+                    "maskinporten.jwksUri" to mockOAuthServer.jwksUrl(DEFAULT_ISSUER).toString(),
                     "maskinporten.scopes" to "kartverk:riktig:scope",
                     "maskinporten.disabled" to "false",
-                    "idporten.issuer" to mockOAuthServer.issuerUrl("testIssuer").toString(),
-                    "idporten.jwksUri" to mockOAuthServer.jwksUrl("testIssuer").toString(),
-                    "idporten.disabled" to "false"
+                    "idporten.issuer" to mockOAuthServer.issuerUrl(DEFAULT_ISSUER).toString(),
+                    "idporten.jwksUri" to mockOAuthServer.jwksUrl(DEFAULT_ISSUER).toString(),
+                    "idporten.disabled" to "false",
+                    "entra.audience" to DEFAULT_AUDIENCE,
+                    "entra.issuer" to mockOAuthServer.issuerUrl(DEFAULT_ISSUER).toString(),
+                    "entra.jwksUri" to mockOAuthServer.jwksUrl(DEFAULT_ISSUER).toString(),
+                    "entra.disabled" to "false"
                 )
             }
         }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/MockOAuth2ServerExtensions.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/MockOAuth2ServerExtensions.kt
@@ -1,17 +1,19 @@
 package no.kartverket.matrikkel.bygning.v1.common
 
+import no.kartverket.matrikkel.bygning.plugins.authentication.ApplicationRoles
 import no.nav.security.mock.oauth2.MockOAuth2Server
 
 class MockOAuth2ServerExtensions {
     companion object {
-        private const val DEFAULT_ISSUER = "testIssuer"
+        internal const val DEFAULT_ISSUER = "testIssuer"
+        internal const val DEFAULT_AUDIENCE = "default"
 
         fun MockOAuth2Server.issueMaskinportenJWT(scope: String = "kartverk:riktig:scope") = issueToken(
             issuerId = DEFAULT_ISSUER,
             claims = mapOf(
                 "consumer" to mapOf(
                     "authority" to "iso6523-actorid-upis",
-                    "ID" to "0192:123456789"
+                    "ID" to "0192:123456789",
                 ),
                 "scope" to scope,
             ),
@@ -21,6 +23,17 @@ class MockOAuth2ServerExtensions {
             issuerId = DEFAULT_ISSUER,
             claims = mapOf(
                 "pid" to "31129956715",
+            ),
+        )
+
+        fun MockOAuth2Server.issueM2MEntraJwt(
+            audience: String = DEFAULT_AUDIENCE,
+            roles: List<String> = listOf(ApplicationRoles.ACCESS_AS_APPLICATION, ApplicationRoles.BYGNING_ARKIVARISK_HISTORIKK)
+        ) = issueToken(
+            audience = audience,
+            issuerId = DEFAULT_ISSUER,
+            claims = mapOf(
+                "roles" to roles,
             ),
         )
     }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/MockOAuth2ServerExtensions.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/MockOAuth2ServerExtensions.kt
@@ -7,6 +7,7 @@ class MockOAuth2ServerExtensions {
     companion object {
         internal const val DEFAULT_ISSUER = "testIssuer"
         internal const val DEFAULT_AUDIENCE = "default"
+        internal const val DEFAULT_PID = "66860475309"
 
         fun MockOAuth2Server.issueMaskinportenJWT(scope: String = "kartverk:riktig:scope") = issueToken(
             issuerId = DEFAULT_ISSUER,
@@ -22,7 +23,7 @@ class MockOAuth2ServerExtensions {
         fun MockOAuth2Server.issueIDPortenJWT() = issueToken(
             issuerId = DEFAULT_ISSUER,
             claims = mapOf(
-                "pid" to "31129956715",
+                "pid" to DEFAULT_PID,
             ),
         )
 

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/bygning/BygningEksternTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/bygning/BygningEksternTest.kt
@@ -29,9 +29,7 @@ class BygningEksternTest : TestApplicationWithDb() {
         val token = mockOAuthServer.issueMaskinportenJWT()
 
         val response = client.get("/v1/bygninger/1") {
-            headers {
-                append("Authorization", "Bearer ${token.serialize()}")
-            }
+            bearerAuth(token.serialize())
         }
 
         assertThat(response.status).isEqualTo(HttpStatusCode.OK)
@@ -47,9 +45,7 @@ class BygningEksternTest : TestApplicationWithDb() {
         val token = mockOAuthServer.issueMaskinportenJWT("feil:scope")
 
         val response = client.get("/v1/bygninger/1") {
-            headers {
-                append("Authorization", "Bearer ${token.serialize()}")
-            }
+           bearerAuth(token.serialize())
         }
 
         assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
@@ -75,9 +71,7 @@ class BygningEksternTest : TestApplicationWithDb() {
             setBody(
                 EgenregistreringRequest.validEgenregistreringMultipleBruksenheter(),
             )
-            headers {
-                append("Authorization", "Bearer ${idportenJWT.serialize()}")
-            }
+            bearerAuth(idportenJWT.serialize())
         }
 
         val maskinportenJWT = mockOAuthServer.issueMaskinportenJWT()
@@ -85,9 +79,7 @@ class BygningEksternTest : TestApplicationWithDb() {
             url {
                 parameters.append("antall", "10")
             }
-            headers {
-                append("Authorization", "Bearer ${maskinportenJWT.serialize()}")
-            }
+            bearerAuth(maskinportenJWT.serialize())
         }
 
         val hendelseContainer = result.body<HendelseContainerResponse>()

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningArkivRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningArkivRouteTest.kt
@@ -1,0 +1,120 @@
+package no.kartverket.matrikkel.bygning.v1.intern.bygning
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.index
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.prop
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import no.kartverket.matrikkel.bygning.TestApplicationWithDb
+import no.kartverket.matrikkel.bygning.routes.v1.intern.bygning.BruksarealInternResponse
+import no.kartverket.matrikkel.bygning.routes.v1.intern.bygning.BruksenhetSimpleResponse
+import no.kartverket.matrikkel.bygning.routes.v1.intern.bygning.BygningSimpleResponse
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EgenregistreringRequest
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueM2MEntraJwt
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueIDPortenJWT
+import no.kartverket.matrikkel.bygning.v1.common.validEgenregistrering
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class BygningArkivRouteTest : TestApplicationWithDb() {
+
+    @Test
+    fun `gitt manglende entra jwt token svarer arkiv med 401`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val response = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=${Instant.now()}")
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt entra jwt token med ingen roller svarer arkiv med 401`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val entraIdToken = mockOAuthServer.issueM2MEntraJwt(roles = emptyList())
+        val response = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=${Instant.now()}") {
+            bearerAuth(entraIdToken.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt entra jwt token med feil rolle svarer arkiv med 401`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val entraIdToken = mockOAuthServer.issueM2MEntraJwt(roles = listOf("feil_rolle"))
+        val response = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=${Instant.now()}") {
+            bearerAuth(entraIdToken.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt entra jwt token med feil audience svarer arkiv med 401`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val entraIdToken = mockOAuthServer.issueM2MEntraJwt(audience = "feil_audience")
+        val response = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=${Instant.now()}") {
+            bearerAuth(entraIdToken.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt et ugyldig dato query parameter svarer bygning arkiv bad request`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val entraIdToken = mockOAuthServer.issueM2MEntraJwt()
+        val response = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=UGYLDIG_DATO") {
+            bearerAuth(entraIdToken.serialize())
+        }
+        assertThat(response.status).isEqualTo(HttpStatusCode.BadRequest)
+    }
+
+    @Test
+    fun `gitt et gyldig dato query parameter svarer bygning arkiv ok`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        client.post("/v1/intern/egenregistreringer") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                EgenregistreringRequest.validEgenregistrering(),
+            )
+            bearerAuth(mockOAuthServer.issueIDPortenJWT().serialize())
+        }
+
+        val entraIdToken = mockOAuthServer.issueM2MEntraJwt()
+        val currentData = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=${Instant.now()}") {
+            bearerAuth(entraIdToken.serialize())
+        }
+        assertThat(currentData.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(currentData.body<BygningSimpleResponse>()).all {
+            prop(BygningSimpleResponse::bruksenheter).hasSize(2)
+            prop(BygningSimpleResponse::bruksenheter).index(0).all {
+                prop(BruksenhetSimpleResponse::totaltBruksareal).isNotNull().all {
+                    prop(BruksarealInternResponse::data).isEqualTo(125.0)
+                }
+            }
+        }
+
+        val oldData = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=2025-01-01T15:15:47.361080Z") {
+            bearerAuth(entraIdToken.serialize())
+        }
+        assertThat(oldData.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(oldData.body<BygningSimpleResponse>()).all {
+            prop(BygningSimpleResponse::bruksenheter).hasSize(2)
+            prop(BygningSimpleResponse::bruksenheter).index(0).all {
+                prop(BruksenhetSimpleResponse::totaltBruksareal).isNull()
+            }
+        }
+    }
+}

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BygningRouteTest.kt
@@ -89,9 +89,7 @@ class BygningRouteTest : TestApplicationWithDb() {
             setBody(
                 EgenregistreringRequest.validEgenregistrering(),
             )
-            headers {
-                append("Authorization", "Bearer ${token.serialize()}")
-            }
+            bearerAuth(token.serialize())
         }
 
         val response = client.get("/v1/intern/bygninger/1/egenregistrert")
@@ -128,51 +126,6 @@ class BygningRouteTest : TestApplicationWithDb() {
                 }
             }
         }
-    }
-
-    @Test
-    fun `gitt et gyldig dato query parameter svarer bygning arkiv bad request`() = testApplication {
-        val client = mainModuleWithDatabaseEnvironmentAndClient()
-
-        val response = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=UGYLDIG_DATO")
-        assertThat(response.status).isEqualTo(HttpStatusCode.BadRequest)
-    }
-
-    @Test
-    fun `gitt et ugyldig dato query parameter svarer bygning arkiv ok`() = testApplication {
-        val client = mainModuleWithDatabaseEnvironmentAndClient()
-        val token = mockOAuthServer.issueIDPortenJWT()
-        
-        client.post("/v1/intern/egenregistreringer") {
-            contentType(ContentType.Application.Json)
-            setBody(
-                EgenregistreringRequest.validEgenregistrering(),
-            )
-            headers {
-                append("Authorization", "Bearer ${token.serialize()}")
-            }
-        }
-
-        val currentData = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=${Instant.now()}")
-        assertThat(currentData.status).isEqualTo(HttpStatusCode.OK)
-        assertThat(currentData.body<BygningSimpleResponse>()).all {
-            prop(BygningSimpleResponse::bruksenheter).hasSize(2)
-            prop(BygningSimpleResponse::bruksenheter).index(0).all {
-                prop(BruksenhetSimpleResponse::totaltBruksareal).isNotNull().all {
-                    prop(BruksarealInternResponse::data).isEqualTo(125.0)
-                }
-            }
-        }
-
-        val oldData = client.get("/v1/intern/arkiv/bygninger/1/egenregistrert?registreringstidspunkt=2025-01-01T15:15:47.361080Z")
-        assertThat(oldData.status).isEqualTo(HttpStatusCode.OK)
-        assertThat(oldData.body<BygningSimpleResponse>()).all {
-            prop(BygningSimpleResponse::bruksenheter).hasSize(2)
-            prop(BygningSimpleResponse::bruksenheter).index(0).all {
-                prop(BruksenhetSimpleResponse::totaltBruksareal).isNull()
-            }
-        }
-
     }
 }
 

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
@@ -36,6 +36,7 @@ import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.Bruksar
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.BruksenhetRegistreringRequest
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.ByggeaarRegistreringRequest
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EgenregistreringRequest
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.DEFAULT_PID
 import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueIDPortenJWT
 import no.kartverket.matrikkel.bygning.v1.common.hasRegistreringstidspunktWithinThreshold
 import no.kartverket.matrikkel.bygning.v1.common.ugyldigEgenregistreringMedKunBruksarealPerEtasje
@@ -288,7 +289,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
                     .prop(BruksenhetInternResponse::totaltBruksareal).isNotNull().all {
                         prop(MultikildeInternResponse<BruksarealInternResponse>::egenregistrert).isNotNull().all {
                             prop(BruksarealInternResponse::metadata).all {
-                                prop(RegisterMetadataInternResponse::registrertAv).isEqualTo("31129956715")
+                                prop(RegisterMetadataInternResponse::registrertAv).isEqualTo(DEFAULT_PID)
                             }
                         }
                     }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/egenregistrering/EgenregistreringRouteTest.kt
@@ -55,9 +55,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
             setBody(
                 EgenregistreringRequest.validEgenregistrering(),
             )
-            headers {
-                append("Authorization", "Bearer ${token.serialize()}")
-            }
+            bearerAuth(token.serialize())
         }
 
         assertThat(response.status).isEqualTo(HttpStatusCode.Created)
@@ -74,9 +72,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
                 setBody(
                     EgenregistreringRequest.validEgenregistrering(),
                 )
-                headers {
-                    append("Authorization", "Bearer ${token.serialize()}")
-                }
+                bearerAuth(token.serialize())
             }
 
             assertThat(response.status).isEqualTo(HttpStatusCode.Created)
@@ -157,9 +153,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
             setBody(
                 EgenregistreringRequest.validEgenregistrering(),
             )
-            headers {
-                append("Authorization", "Bearer ${token.serialize()}")
-            }
+            bearerAuth(token.serialize())
         }
 
         assertThat(response.status).isEqualTo(HttpStatusCode.Created)
@@ -207,9 +201,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
                 setBody(
                     EgenregistreringRequest.validEgenregistrering(),
                 )
-                headers {
-                    append("Authorization", "Bearer ${token.serialize()}")
-                }
+                bearerAuth(token.serialize())
             }
             assertThat(egenregistrering1.status).isEqualTo(HttpStatusCode.Created)
 
@@ -237,9 +229,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
                         ),
                     ),
                 )
-                headers {
-                    append("Authorization", "Bearer ${token.serialize()}")
-                }
+                bearerAuth(token.serialize())
             }
             assertThat(egenregistrering2.status).isEqualTo(HttpStatusCode.Created)
 
@@ -280,11 +270,9 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
             val response = client.post("/v1/intern/egenregistreringer") {
                 contentType(ContentType.Application.Json)
                 setBody(
-                        EgenregistreringRequest.validEgenregistrering(),
+                    EgenregistreringRequest.validEgenregistrering(),
                 )
-                headers {
-                    append("Authorization", "Bearer ${token.serialize()}")
-                }
+                bearerAuth(token.serialize())
             }
 
             assertThat(response.status).isEqualTo(HttpStatusCode.Created)
@@ -318,9 +306,7 @@ class EgenregistreringRouteTest : TestApplicationWithDb() {
                 setBody(
                     EgenregistreringRequest.ugyldigEgenregistreringMedKunBruksarealPerEtasje(),
                 )
-                headers {
-                    append("Authorization", "Bearer ${token.serialize()}")
-                }
+                bearerAuth(token.serialize())
             }
 
             assertThat(response.status).isEqualTo(HttpStatusCode.BadRequest)

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
@@ -21,6 +21,7 @@ import io.github.smiley4.schemakenerator.swagger.handleCoreAnnotations
 import io.github.smiley4.schemakenerator.swagger.handleSchemaAnnotations
 import io.github.smiley4.schemakenerator.swagger.withTitle
 import io.ktor.server.application.*
+import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.ENTRA_ID_ARKIVARISK_HISTORIKK_NAME
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.IDPORTEN_PROVIDER_NAME
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.MASKINPORTEN_PROVIDER_NAME
 import java.time.Instant
@@ -97,6 +98,12 @@ private fun PluginConfigDsl.installOpenApiSpec(name: String, title: String, vers
             }
 
             securityScheme(IDPORTEN_PROVIDER_NAME) {
+                type = AuthType.HTTP
+                scheme = AuthScheme.BEARER
+                bearerFormat = "jwt"
+            }
+
+            securityScheme(ENTRA_ID_ARKIVARISK_HISTORIKK_NAME) {
                 type = AuthType.HTTP
                 scheme = AuthScheme.BEARER
                 bearerFormat = "jwt"

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/authentication/Authentication.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/authentication/Authentication.kt
@@ -9,20 +9,15 @@ import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
 import io.ktor.server.config.*
-import io.ktor.util.*
 import no.kartverket.matrikkel.bygning.config.Env
 import no.kartverket.matrikkel.bygning.plugins.authentication.ApplicationRoles.ACCESS_AS_APPLICATION
 import no.kartverket.matrikkel.bygning.plugins.authentication.ApplicationRoles.BYGNING_ARKIVARISK_HISTORIKK
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.ENTRA_ID_ARKIVARISK_HISTORIKK_NAME
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.IDPORTEN_PROVIDER_NAME
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.MASKINPORTEN_PROVIDER_NAME
-import no.kartverket.matrikkel.bygning.plugins.authentication.mock.mockJwtPrincipalForProvider
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import no.kartverket.matrikkel.bygning.plugins.authentication.mock.mockJwt
 import java.net.URI
 import java.util.concurrent.TimeUnit
-
-private val log: Logger = LoggerFactory.getLogger(object {}::class.java)
 
 object AuthenticationConstants {
     const val IDPORTEN_PROVIDER_NAME = "idporten"
@@ -58,8 +53,7 @@ fun Application.configureAuthentication(config: ApplicationConfig) {
 
 private fun AuthenticationConfig.jwtMaskinporten(config: ApplicationConfig) {
     if (Env.isLocal() && isProviderDisabled(config, MASKINPORTEN_PROVIDER_NAME)) {
-        logDisabledProviderWarning(MASKINPORTEN_PROVIDER_NAME)
-        mockJwtPrincipalForProvider(MASKINPORTEN_PROVIDER_NAME)
+        mockJwt(MASKINPORTEN_PROVIDER_NAME)
     } else {
         jwt(MASKINPORTEN_PROVIDER_NAME) {
             val authConfig = JWTAuthenticationConfig(
@@ -80,11 +74,10 @@ private fun AuthenticationConfig.jwtMaskinporten(config: ApplicationConfig) {
 
 private fun AuthenticationConfig.jwtIDPorten(config: ApplicationConfig) {
     if (Env.isLocal() && isProviderDisabled(config, IDPORTEN_PROVIDER_NAME)) {
-        logDisabledProviderWarning(IDPORTEN_PROVIDER_NAME)
-        mockJwtPrincipalForProvider(IDPORTEN_PROVIDER_NAME) {
+        mockJwt(IDPORTEN_PROVIDER_NAME) {
             jwtCreator {
                 val token = JWT.create()
-                    .withClaim("pid", "31129956715")
+                    .withClaim("pid", "66860475309")
                     .sign(Algorithm.none())
 
                 JWT.decode(token)
@@ -109,8 +102,7 @@ private fun AuthenticationConfig.jwtIDPorten(config: ApplicationConfig) {
 
 private fun AuthenticationConfig.jwtEntraIdArkivariskHistorikk(config: ApplicationConfig) {
     if (Env.isLocal() && isProviderDisabled(config, "entra")) {
-        logDisabledProviderWarning(ENTRA_ID_ARKIVARISK_HISTORIKK_NAME)
-        mockJwtPrincipalForProvider(ENTRA_ID_ARKIVARISK_HISTORIKK_NAME)
+        mockJwt(ENTRA_ID_ARKIVARISK_HISTORIKK_NAME)
     } else {
         jwt(ENTRA_ID_ARKIVARISK_HISTORIKK_NAME) {
             val authConfig = JWTAuthenticationConfig(
@@ -132,7 +124,3 @@ private fun AuthenticationConfig.jwtEntraIdArkivariskHistorikk(config: Applicati
 
 private fun isProviderDisabled(config: ApplicationConfig, name: String): Boolean =
     config.property("${name}.disabled").getString().toBoolean()
-
-
-private fun logDisabledProviderWarning(name: String) =
-    log.warn("${name.toUpperCasePreservingASCIIRules()} autentisering er deaktivert! Dette skal kun gjøres lokalt.")

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/authentication/mock/MockJWTConfig.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/authentication/mock/MockJWTConfig.kt
@@ -5,12 +5,17 @@ import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.interfaces.Payload
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
+import io.ktor.util.*
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
-internal fun AuthenticationConfig.mockJwtPrincipalForProvider(
+private val log: Logger = LoggerFactory.getLogger(object {}::class.java)
+
+internal fun AuthenticationConfig.mockJwt(
     name: String,
     configure: MockJWTConfig.() -> Unit = { MockJWTConfig(name) }
 ) {
-
+    log.warn("${name.toUpperCasePreservingASCIIRules()} autentisering er deaktivert! Dette skal kun gjøres lokalt.")
     val config = MockJWTConfig(name).apply(configure)
     register(MockJWTAuthenticationProvider(config))
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/authentication/mock/MockJWTConfig.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/authentication/mock/MockJWTConfig.kt
@@ -1,12 +1,37 @@
 package no.kartverket.matrikkel.bygning.plugins.authentication.mock
 
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.Payload
 import io.ktor.server.auth.*
-import no.kartverket.matrikkel.bygning.plugins.authentication.DigDirPrincipal
+import io.ktor.server.auth.jwt.*
 
-internal class MockJWTAuthenticationProvider(config: MockJWTConfig) : AuthenticationProvider(config) {
-    override suspend fun onAuthenticate(context: AuthenticationContext) {
-        context.principal(DigDirPrincipal("31129956715"))
+internal fun AuthenticationConfig.mockJwtPrincipalForProvider(
+    name: String,
+    configure: MockJWTConfig.() -> Unit = { MockJWTConfig(name) }
+) {
+
+    val config = MockJWTConfig(name).apply(configure)
+    register(MockJWTAuthenticationProvider(config))
+}
+
+internal class MockJWTConfig(name: String) : AuthenticationProvider.Config(name) {
+    internal var jwtCreator: () -> Payload = {
+        val token = JWT.create()
+            .sign(Algorithm.none())
+
+        JWT.decode(token)
+    }
+
+    fun jwtCreator(jwtCreator: () -> Payload) {
+        this.jwtCreator = jwtCreator
     }
 }
 
-internal class MockJWTConfig(name: String) : AuthenticationProvider.Config(name)
+private class MockJWTAuthenticationProvider(config: MockJWTConfig) : AuthenticationProvider(config) {
+    private val jwtCreator: () -> Payload = config.jwtCreator
+
+    override suspend fun onAuthenticate(context: AuthenticationContext) {
+        context.principal(JWTPrincipal(this.jwtCreator()))
+    }
+}

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/RouteExtensions.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/RouteExtensions.kt
@@ -1,9 +1,13 @@
 package no.kartverket.matrikkel.bygning.routes
 
 import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
+import io.ktor.server.plugins.*
 import io.ktor.server.routing.*
 
-
-inline fun <reified T : Any> RoutingCall.principalOrThrow(): T {
-    return principal<T>() ?: throw IllegalStateException("No principal was found on the incoming call, but was needed to authenticate.")
+/**
+ * Henter ut fnr fra pid claimet i IDPorten token.
+ */
+fun RoutingCall.getFnr(): String {
+    return this.principal<JWTPrincipal>()?.get("pid") ?: throw BadRequestException("pid mangler i JWTCredential")
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/InternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/InternRoutes.kt
@@ -1,10 +1,12 @@
 package no.kartverket.matrikkel.bygning.routes.v1.intern
 
 import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.ktor.server.auth.*
 import io.ktor.server.routing.*
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
 import no.kartverket.matrikkel.bygning.application.egenregistrering.EgenregistreringService
 import no.kartverket.matrikkel.bygning.plugins.OpenApiSpecIds
+import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.ENTRA_ID_ARKIVARISK_HISTORIKK_NAME
 import no.kartverket.matrikkel.bygning.routes.v1.intern.bygning.arkivRouting
 import no.kartverket.matrikkel.bygning.routes.v1.intern.bygning.bygningRouting
 import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.egenregistreringRouting
@@ -29,8 +31,10 @@ fun Route.internRouting(
         route("bygninger") {
             bygningRouting(bygningService)
         }
-        route("arkiv") {
-            arkivRouting(bygningService)
+        authenticate(ENTRA_ID_ARKIVARISK_HISTORIKK_NAME) {
+            route("arkiv") {
+                arkivRouting(bygningService)
+            }
         }
     }
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/ArkivRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/ArkivRoutes.kt
@@ -7,6 +7,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
+import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.ENTRA_ID_ARKIVARISK_HISTORIKK_NAME
 import no.kartverket.matrikkel.bygning.routes.v1.common.domainErrorToResponse
 import no.kartverket.matrikkel.bygning.routes.v1.common.toInstant
 import java.time.Instant
@@ -22,6 +23,7 @@ fun Route.arkivRouting(
                         summary = "Hent egenregistrert data for en bygning for et gitt registreringstidspunkt"
                         description =
                             "Henter tidligere versjon av egenregistrert data for en bygning basert på informasjonsgrunnlaget ved gitt registreringstidspunkt"
+                        securitySchemeNames = listOf(ENTRA_ID_ARKIVARISK_HISTORIKK_NAME)
                         request {
                             pathParameter<String>("bygningId") {
                                 required = true
@@ -69,6 +71,7 @@ fun Route.arkivRouting(
                                 summary = "Hent egenregistrert data for en bruksenhet for et gitt registreringstidspunkt"
                                 description =
                                     "Henter tidligere versjon av egenregistrert data for en bruksenhet basert på informasjonsgrunnlaget ved gitt registreringstidspunkt"
+                                securitySchemeNames = listOf(ENTRA_ID_ARKIVARISK_HISTORIKK_NAME)
                                 request {
                                     pathParameter<String>("bygningId") {
                                         required = true

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregisteringRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregisteringRoutes.kt
@@ -14,8 +14,7 @@ import no.kartverket.matrikkel.bygning.application.egenregistrering.Egenregistre
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.IDPORTEN_PROVIDER_NAME
-import no.kartverket.matrikkel.bygning.plugins.authentication.DigDirPrincipal
-import no.kartverket.matrikkel.bygning.routes.principalOrThrow
+import no.kartverket.matrikkel.bygning.routes.getFnr
 import no.kartverket.matrikkel.bygning.routes.v1.common.ErrorResponse
 import no.kartverket.matrikkel.bygning.routes.v1.common.domainErrorToResponse
 import no.kartverket.matrikkel.bygning.routes.v1.common.exceptionToDomainError
@@ -93,12 +92,11 @@ fun Route.egenregistreringRouting(egenregistreringService: EgenregistreringServi
                 }
             },
         ) {
-            val principal = call.principalOrThrow<DigDirPrincipal>()
-
+            val fnr = call.getFnr()
             // Kan også wrappes i en runCatching. Enten her eller ved å lage en custom receive-metode.
             val egenregistreringRequest = call.receive<EgenregistreringRequest>()
 
-            val (status, body) = runCatching { egenregistreringRequest.toEgenregistrering(eier = principal.id) }
+            val (status, body) = runCatching { egenregistreringRequest.toEgenregistrering(eier = fnr) }
                 .mapError(::exceptionToDomainError)
                 .andThen { egenregistreringService.addEgenregistrering(it) }
                 .mapBoth(

--- a/web/src/main/resources/application-local.conf
+++ b/web/src/main/resources/application-local.conf
@@ -33,3 +33,14 @@ idporten {
   issuer = "https://test.idporten.no/"
   issuer = ${?IDPORTEN_ISSUER}
 }
+
+entra {
+  disabled = true
+  disabled = ${?ENTRA_DISABLED}
+  audience = "default"
+  audience = ${?AZURE_APP_CLIENT_ID}
+  jwksUri = "https://login.microsoftonline.com/7f74c8a2-43ce-46b2-b0e8-b6306cba73a3/discovery/v2.0/keys"
+  jwksUri = ${?AZURE_OPENID_CONFIG_JWKS_URI}
+  issuer = "https://login.microsoftonline.com/7f74c8a2-43ce-46b2-b0e8-b6306cba73a3/v2.0"
+  issuer = ${?AZURE_OPENID_CONFIG_ISSUER}
+}

--- a/web/src/main/resources/application.conf
+++ b/web/src/main/resources/application.conf
@@ -20,3 +20,9 @@ idporten {
   jwksUri = ${IDPORTEN_JWKS_URI}
   issuer = ${IDPORTEN_ISSUER}
 }
+
+entra {
+  audience = ${AZURE_APP_CLIENT_ID}
+  jwksUri = ${AZURE_OPENID_CONFIG_JWKS_URI}
+  issuer = ${AZURE_OPENID_CONFIG_ISSUER}
+}


### PR DESCRIPTION

* Legger til ny auth provider som validerer issuer, audience og custom roller
* Går tilbake fra custom principal og beholder i stedet JWTPrincipal da det er mer felles for de ulike providerne.
* Skriver om mock oppsettet slik at vi setter korrekt JWTPrincipal. Har mulighet for default token, men også mulig å overstyre tokenet for de ulike providerne.
* Flyttet på arkiv-tester for å unngå for mange tester i samme fil.

TB-188