### PR TITLE
TB-203: Oppgraderer til ktor-swagger-ui 5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,7 @@ mockkVersion = "1.13.17"
 assertkVersion = "0.28.1"
 norwegianCommonsVersion = "0.16.0"
 kotlinResultVersion = "2.0.1"
-ktorSwaggerUIVersion = "4.1.6"
-smileySchemaKeneratorVersion = "1.6.5"
+ktorSwaggerUIVersion = "5.0.0"
 mockOauth2Server = "2.1.10"
 matrikkelWsClientVersion = "4.18.1.0"
 jacksonVersion = "2.18.2"
@@ -60,10 +59,11 @@ norwegian-commons = { group = "no.bekk.bekkopen", name = "nocommons", version.re
 
 kotlin-result = { group = "com.michael-bull.kotlin-result", name = "kotlin-result", version.ref = "kotlinResultVersion" }
 
+ktor-openapi = { group = "io.github.smiley4", name = "ktor-openapi", version.ref = "ktorSwaggerUIVersion" }
 ktor-swagger-ui = { group = "io.github.smiley4", name = "ktor-swagger-ui", version.ref = "ktorSwaggerUIVersion" }
-schema-kenerator-core = { group = "io.github.smiley4", name = "schema-kenerator-core", version.ref = "smileySchemaKeneratorVersion" }
-schema-kenerator-reflection = { group = "io.github.smiley4", name = "schema-kenerator-reflection", version.ref = "smileySchemaKeneratorVersion" }
-schema-kenerator-swagger = { group = "io.github.smiley4", name = "schema-kenerator-swagger", version.ref = "smileySchemaKeneratorVersion" }
+schema-kenerator-core = { group = "io.github.smiley4", name = "schema-kenerator-core" }
+schema-kenerator-reflection = { group = "io.github.smiley4", name = "schema-kenerator-reflection" }
+schema-kenerator-swagger = { group = "io.github.smiley4", name = "schema-kenerator-swagger" }
 
 fasterxml-jackson-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jacksonVersion" }
 [plugins]

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -12,6 +12,14 @@ plugins {
     `jvm-test-suite`
 }
 
+java {
+    consistentResolution {
+        // Må trekke noe transitive runtime-avhengigheter inn på compileClasspath for swagger-ting.
+        // Dette gjør at vi slipper å angi versjon eksplisitt.
+        useRuntimeClasspathVersions()
+    }
+}
+
 dependencies {
     implementation(project(":application"))
     implementation(project(":infrastructure"))
@@ -39,6 +47,7 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx)
 
     // OpenAPI / Swagger
+    implementation(libs.ktor.openapi)
     implementation(libs.ktor.swagger.ui)
     implementation(libs.schema.kenerator.core)
     implementation(libs.schema.kenerator.reflection)

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -120,10 +120,22 @@ fun Application.mainModule() {
                 route("api.json") {
                     openApi(specId)
                 }
-                route("swagger-ui") {
-                    swaggerUI("/$specId/api.json")
-                }
             }
+        }
+        route(OpenApiSpecIds.INTERN) {
+            route("swagger-ui") {
+                swaggerUI("/${OpenApiSpecIds.INTERN}/api.json")
+            }
+        }
+        route("swagger-ui") {
+            swaggerUI(
+                mapOf(
+                    "Berettiget interesse" to "/${OpenApiSpecIds.BERETTIGET_INTERESSE}/api.json",
+                    "Med persondata" to "/${OpenApiSpecIds.MED_PERSONDATA}/api.json",
+                    "Uten persondata" to "/${OpenApiSpecIds.UTEN_PERSONDATA}/api.json",
+                    "Hendelseslogg" to "/${OpenApiSpecIds.HENDELSER}/api.json",
+                )
+            )
         }
 
         route("v1") {

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/Application.kt
@@ -1,8 +1,7 @@
 package no.kartverket.matrikkel.bygning
 
-import io.github.smiley4.ktorswaggerui.dsl.routing.route
-import io.github.smiley4.ktorswaggerui.routing.openApiSpec
-import io.github.smiley4.ktorswaggerui.routing.swaggerUI
+import io.github.smiley4.ktoropenapi.openApi
+import io.github.smiley4.ktorswaggerui.swaggerUI
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
@@ -119,7 +118,7 @@ fun Application.mainModule() {
         ).forEach { specId ->
             route(specId) {
                 route("api.json") {
-                    openApiSpec(specId)
+                    openApi(specId)
                 }
                 route("swagger-ui") {
                     swaggerUI("/$specId/api.json")

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
@@ -1,30 +1,14 @@
 package no.kartverket.matrikkel.bygning.plugins
 
-import io.github.smiley4.ktorswaggerui.SwaggerUI
-import io.github.smiley4.ktorswaggerui.data.AuthScheme
-import io.github.smiley4.ktorswaggerui.data.AuthType
-import io.github.smiley4.ktorswaggerui.dsl.config.PluginConfigDsl
-import io.github.smiley4.schemakenerator.core.annotations.Format
-import io.github.smiley4.schemakenerator.core.annotations.Type
-import io.github.smiley4.schemakenerator.core.connectSubTypes
-import io.github.smiley4.schemakenerator.core.data.AnnotationData
-import io.github.smiley4.schemakenerator.core.data.PrimitiveTypeData
-import io.github.smiley4.schemakenerator.core.data.TypeId
-import io.github.smiley4.schemakenerator.core.handleNameAnnotation
-import io.github.smiley4.schemakenerator.reflection.collectSubTypes
-import io.github.smiley4.schemakenerator.reflection.processReflection
-import io.github.smiley4.schemakenerator.swagger.compileReferencingRoot
-import io.github.smiley4.schemakenerator.swagger.customizeProperties
-import io.github.smiley4.schemakenerator.swagger.data.TitleType
-import io.github.smiley4.schemakenerator.swagger.generateSwaggerSchema
-import io.github.smiley4.schemakenerator.swagger.handleCoreAnnotations
-import io.github.smiley4.schemakenerator.swagger.handleSchemaAnnotations
-import io.github.smiley4.schemakenerator.swagger.withTitle
+import io.github.smiley4.ktoropenapi.OpenApi
+import io.github.smiley4.ktoropenapi.config.AuthScheme
+import io.github.smiley4.ktoropenapi.config.AuthType
+import io.github.smiley4.ktoropenapi.config.OpenApiPluginConfig
+import io.github.smiley4.ktoropenapi.config.SchemaGenerator
 import io.ktor.server.application.*
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.ENTRA_ID_ARKIVARISK_HISTORIKK_NAME
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.IDPORTEN_PROVIDER_NAME
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.MASKINPORTEN_PROVIDER_NAME
-import java.time.Instant
 
 object OpenApiSpecIds {
     const val INTERN = "intern"
@@ -35,7 +19,7 @@ object OpenApiSpecIds {
 }
 
 fun Application.configureOpenAPI() {
-    install(SwaggerUI) {
+    install(OpenApi) {
         installOpenApiSpec(
             name = OpenApiSpecIds.INTERN,
             title = "API for egenregistrering av bygningsdata",
@@ -64,34 +48,12 @@ fun Application.configureOpenAPI() {
     }
 }
 
-private fun PluginConfigDsl.installOpenApiSpec(name: String, title: String, version: String) {
+private fun OpenApiPluginConfig.installOpenApiSpec(name: String, title: String, version: String) {
     spec(name) {
         schemas {
-            generator = { type ->
-                type
-                    .collectSubTypes()
-                    .processReflection {
-                        customProcessor<Instant> {
-                            createDefaultPrimitiveTypeWithCustomTypeAndFormat<Instant>(
-                                type = "string",
-                                format = "date-time",
-                            )
-                        }
-                    }
-                    .connectSubTypes()
-                    .handleNameAnnotation()
-                    .generateSwaggerSchema()
-                    // Setter nullable properties til ikke nullable i Swagger skjemaet
-                    // Gjør at vi unngår oneOf(null, type) i generert Swagger skjema.
-                    .customizeProperties { propertyData, propertySchema ->
-                        if (propertyData.nullable) {
-                            propertySchema.nullable = false
-                        }
-                    }
-                    .handleCoreAnnotations()
-                    .handleSchemaAnnotations()
-                    .withTitle(TitleType.SIMPLE)
-                    .compileReferencingRoot()
+            generator = SchemaGenerator.reflection {
+                customGenerator(SchemaGenerator.TypeOverwrites.Instant())
+                explicitNullTypes = false
             }
         }
         info {
@@ -128,26 +90,4 @@ private fun PluginConfigDsl.installOpenApiSpec(name: String, title: String, vers
             }
         }
     }
-}
-
-/**
- * Legger på en type- og format-annotasjoner gjør at type og format blir satt korret på swagger schema
- * Siden Instant er en ekstern-klasse må vi sette disse som en del av prosessering dynamisk i stedet for å sette annotasjonene direkte på klassen
- */
-private inline fun <reified T> createDefaultPrimitiveTypeWithCustomTypeAndFormat(type: String, format: String): PrimitiveTypeData {
-    return PrimitiveTypeData(
-        id = TypeId.build(T::class.qualifiedName!!),
-        simpleName = T::class.simpleName!!,
-        qualifiedName = T::class.qualifiedName!!,
-        annotations = mutableListOf(
-            AnnotationData(
-                name = Type::class.qualifiedName!!,
-                values = mutableMapOf("type" to type),
-            ),
-            AnnotationData(
-                name = Format::class.qualifiedName!!,
-                values = mutableMapOf("format" to format),
-            ),
-        ),
-    )
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/plugins/OpenAPI.kt
@@ -5,6 +5,7 @@ import io.github.smiley4.ktoropenapi.config.AuthScheme
 import io.github.smiley4.ktoropenapi.config.AuthType
 import io.github.smiley4.ktoropenapi.config.OpenApiPluginConfig
 import io.github.smiley4.ktoropenapi.config.SchemaGenerator
+import io.github.smiley4.schemakenerator.swagger.data.RefType
 import io.ktor.server.application.*
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.ENTRA_ID_ARKIVARISK_HISTORIKK_NAME
 import no.kartverket.matrikkel.bygning.plugins.authentication.AuthenticationConstants.IDPORTEN_PROVIDER_NAME
@@ -54,8 +55,10 @@ private fun OpenApiPluginConfig.installOpenApiSpec(name: String, title: String, 
             generator = SchemaGenerator.reflection {
                 customGenerator(SchemaGenerator.TypeOverwrites.Instant())
                 explicitNullTypes = false
+                referencePath = RefType.SIMPLE
             }
         }
+        postBuild = { openApi, _ -> openApi.externalDocs = null } // Ellers peker den på et sted hvor det ikke ligger noe
         info {
             this.title = title
             this.version = version

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/EksternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/EksternRoutes.kt
@@ -1,6 +1,6 @@
 package no.kartverket.matrikkel.bygning.routes.v1.ekstern
 
-import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.github.smiley4.ktoropenapi.route
 import io.ktor.http.*
 import io.ktor.server.auth.*
 import io.ktor.server.routing.*
@@ -41,7 +41,7 @@ fun Route.eksternRouting(
 private fun Route.routeWithMaskinporten(path: String, openApiSpecId: String, build: Route.() -> Unit) = route(
     path,
     {
-        specId = openApiSpecId
+        specName = openApiSpecId
         securitySchemeNames = listOf(MASKINPORTEN_PROVIDER_NAME)
         response {
             code(HttpStatusCode.Unauthorized) {

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/berettigetinteresse/bygning/BygningBerettigetInteresseRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/berettigetinteresse/bygning/BygningBerettigetInteresseRoutes.kt
@@ -1,7 +1,7 @@
 package no.kartverket.matrikkel.bygning.routes.v1.ekstern.berettigetinteresse.bygning
 
 import com.github.michaelbull.result.mapBoth
-import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.github.smiley4.ktoropenapi.get
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/hendelse/HendelseRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/hendelse/HendelseRoutes.kt
@@ -1,6 +1,6 @@
 package no.kartverket.matrikkel.bygning.routes.v1.ekstern.hendelse
 
-import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.github.smiley4.ktoropenapi.get
 import io.ktor.http.*
 import io.ktor.server.plugins.*
 import io.ktor.server.response.*

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/medpersondata/MedPersondataRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/medpersondata/MedPersondataRoutes.kt
@@ -1,6 +1,5 @@
 package no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata
 
-import io.github.smiley4.ktorswaggerui.dsl.routing.route
 import io.ktor.server.routing.*
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
 import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.bruksenhetMedPersondataRouting

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/medpersondata/bygning/BygningMedPersondataRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/medpersondata/bygning/BygningMedPersondataRoutes.kt
@@ -1,7 +1,7 @@
 package no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning
 
 import com.github.michaelbull.result.mapBoth
-import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.github.smiley4.ktoropenapi.get
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/utenpersondata/bygning/BygningUtenPersondataRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/utenpersondata/bygning/BygningUtenPersondataRoutes.kt
@@ -1,7 +1,7 @@
 package no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning
 
 import com.github.michaelbull.result.mapBoth
-import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.github.smiley4.ktoropenapi.get
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/InternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/InternRoutes.kt
@@ -1,6 +1,6 @@
 package no.kartverket.matrikkel.bygning.routes.v1.intern
 
-import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.github.smiley4.ktoropenapi.route
 import io.ktor.server.auth.*
 import io.ktor.server.routing.*
 import no.kartverket.matrikkel.bygning.application.bygning.BygningService
@@ -20,7 +20,7 @@ fun Route.internRouting(
     route(
         "/intern",
         {
-            specId = OpenApiSpecIds.INTERN
+            specName = OpenApiSpecIds.INTERN
         },
     ) {
         route("kodelister") {

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/ArkivRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/ArkivRoutes.kt
@@ -1,7 +1,7 @@
 package no.kartverket.matrikkel.bygning.routes.v1.intern.bygning
 
 import com.github.michaelbull.result.mapBoth
-import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.github.smiley4.ktoropenapi.get
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BruksenhetRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BruksenhetRoutes.kt
@@ -1,8 +1,8 @@
 package no.kartverket.matrikkel.bygning.routes.v1.intern.bygning
 
 import com.github.michaelbull.result.mapBoth
-import io.github.smiley4.ktorswaggerui.dsl.routing.get
-import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.github.smiley4.ktoropenapi.get
+import io.github.smiley4.ktoropenapi.route
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/bygning/BygningRoutes.kt
@@ -1,8 +1,8 @@
 package no.kartverket.matrikkel.bygning.routes.v1.intern.bygning
 
 import com.github.michaelbull.result.mapBoth
-import io.github.smiley4.ktorswaggerui.dsl.routing.get
-import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.github.smiley4.ktoropenapi.get
+import io.github.smiley4.ktoropenapi.route
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregisteringRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/intern/egenregistrering/EgenregisteringRoutes.kt
@@ -4,7 +4,7 @@ import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.mapBoth
 import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.runCatching
-import io.github.smiley4.ktorswaggerui.dsl.routing.post
+import io.github.smiley4.ktoropenapi.post
 import io.ktor.http.*
 import io.ktor.server.auth.*
 import io.ktor.server.request.*

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/kodeliste/KodelisteRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/kodeliste/KodelisteRoutes.kt
@@ -1,6 +1,6 @@
 package no.kartverket.matrikkel.bygning.routes.v1.kodeliste
 
-import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.github.smiley4.ktoropenapi.get
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*


### PR DESCRIPTION
Fjerner også pakkenavn fra typenavnene (TB-205)
Samler eksterne OpenAPI-spesifikasjoner i samme Swagger-UI nå som det er mulig