### PR TITLE
Fiks manglende protected block på ekstern routes

### DIFF
--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/EksternRoutes.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/EksternRoutes.kt
@@ -18,7 +18,14 @@ fun Route.eksternRouting(
     hendelseService: HendelseService,
 ) {
     authenticate(MASKINPORTEN_PROVIDER_NAME) {
-        route("/") {
+        route(
+            "/",
+            {
+                // Egentlig skal denne ikke være nødvendig siden routen er wrappet i en authenticate block
+                // Ser ut til å være en bug i ktor-openapi
+                protected = true
+            },
+        ) {
             routeWithMaskinporten("berettigetinteresse", OpenApiSpecIds.BERETTIGET_INTERESSE) {
                 berettigetInteresseRouting(bygningService)
             }


### PR DESCRIPTION
Ser ut til å være en bug i ktor-openapi, vet ikke helt hvorfor det skjer, kanskje noe med extension funksjonen som ikke blir plukka opp.