### PR TITLE
Pin docker image til spesifikk digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jdk-alpine
+FROM eclipse-temurin:21-jdk-alpine@sha256:cafcfad1d9d3b6e7dd983fa367f085ca1c846ce792da59bcb420ac4424296d56
 
 ENV USER_ID=150 \
     USER_NAME=apprunner \


### PR DESCRIPTION
Fått ut hash fra `docker buildx imagetools inspect eclipse-temurin:21-jdk-alpine`. Kan eventuelt leses fra [Docker Hub](https://hub.docker.com/layers/library/eclipse-temurin/21-alpine/images/sha256-1b8c1c466d6a7c739cbac9c8a1bd56d5cadfeea900d65b99db6b992c3b7e19ef)