### PR TITLE
Bruk av prosesskode i eksterne responser

### DIFF
--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/medpersondata/bygning/BygningMedPersondataResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/medpersondata/bygning/BygningMedPersondataResponse.kt
@@ -74,7 +74,8 @@ data class RegisterMetadataMedPersondataResponse(
     @Serializable(with = InstantSerializer::class)
     val registreringstidspunkt: Instant,
     val registrertAv: String,
-    val kildemateriale: KildematerialeKode? = null
+    val kildemateriale: KildematerialeKode? = null,
+    val prosess: ProsessKode?
 )
 
 fun Bygning.toBygningMedPersondataResponse(): BygningMedPersondataResponse = BygningMedPersondataResponse(
@@ -99,6 +100,7 @@ internal fun <U, T : Felt<U>, O : FeltMedPersondataResponse<U>?> toFeltMedPerson
             registreringstidspunkt = felt.metadata.registreringstidspunkt,
             registrertAv = felt.metadata.registrertAv.value,
             kildemateriale = felt.metadata.kildemateriale,
+            prosess = felt.metadata.prosess,
         ),
     )
 }

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/utenpersondata/bygning/BygningUtenPersondataResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/utenpersondata/bygning/BygningUtenPersondataResponse.kt
@@ -8,6 +8,7 @@ import no.kartverket.matrikkel.bygning.application.models.kodelister.AvlopKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.OppvarmingKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.ProsessKode
 import no.kartverket.matrikkel.bygning.application.models.kodelister.VannforsyningKode
 import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.AvlopKodeUtenPersondataResponse
 import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.BruksarealUtenPersondataResponse
@@ -82,7 +83,8 @@ sealed interface FeltUtenPersondataResponse<T> {
 data class RegisterMetadataUtenPersondataResponse(
     @Serializable(with = InstantSerializer::class)
     val registreringstidspunkt: Instant,
-    val kildemateriale: KildematerialeKode? = null
+    val kildemateriale: KildematerialeKode? = null,
+    val prosess: ProsessKode?
 )
 
 
@@ -107,6 +109,7 @@ private fun <U, T : Felt<U>, O : FeltUtenPersondataResponse<U>?> toFeltUtenPerso
         RegisterMetadataUtenPersondataResponse(
             registreringstidspunkt = felt.metadata.registreringstidspunkt,
             kildemateriale = felt.metadata.kildemateriale,
+            prosess = felt.metadata.prosess,
         ),
     )
 }


### PR DESCRIPTION
prosess skal oppluse egenregistrerte data i eksterne responser slik at det er lett for brukerene å vite hvilken data de konsumerer

-TB-196