### PR TITLE
Fjern egenregistrerte verdier med opphørsår fra bruksenhetsaggregat

### DIFF
--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Bygning.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/Bygning.kt
@@ -122,4 +122,8 @@ sealed interface Felt<T> {
         override val data: OppvarmingKode,
         override val metadata: RegisterMetadata
     ) : Felt<OppvarmingKode>
+
+    fun erOpphoert(): Boolean {
+        return metadata.gyldighetsperiode.opphoersaar != null
+    }
 }

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningEgenregistreringAggregering.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningEgenregistreringAggregering.kt
@@ -54,23 +54,23 @@ fun Bruksenhet.applyEgenregistrering(egenregistrering: Egenregistrering): Brukse
                 metadata.withKildemateriale(bruksenhetRegistrering.bruksarealRegistrering?.kildemateriale),
             )
         },
-        vannforsyning = this.vannforsyning.aggregate(bruksenhetRegistrering.vannforsyningRegistrering) {
+        vannforsyning = this.vannforsyning.aggregate(bruksenhetRegistrering.vannforsyningRegistrering) { vannforsyningRegistrering ->
             Vannforsyning(
-                data = it.vannforsyning,
+                data = vannforsyningRegistrering.vannforsyning,
                 metadata = metadata
-                    .withKildemateriale(it.kildemateriale)
+                    .withKildemateriale(vannforsyningRegistrering.kildemateriale)
                     .withGyldighetsperiode(
-                        Gyldighetsperiode.of(gyldighetsaar = it.gyldighetsaar, opphoersaar = it.opphoersaar),
+                        Gyldighetsperiode.of(gyldighetsaar = vannforsyningRegistrering.gyldighetsaar, opphoersaar = vannforsyningRegistrering.opphoersaar),
                     ),
             ).takeIf { !it.erOpphoert() }
         },
-        avlop = this.avlop.aggregate(bruksenhetRegistrering.avlopRegistrering) {
+        avlop = this.avlop.aggregate(bruksenhetRegistrering.avlopRegistrering) { avlopRegistrering ->
             Avlop(
-                data = it.avlop,
+                data = avlopRegistrering.avlop,
                 metadata = metadata
-                    .withKildemateriale(it.kildemateriale)
+                    .withKildemateriale(avlopRegistrering.kildemateriale)
                     .withGyldighetsperiode(
-                        Gyldighetsperiode.of(gyldighetsaar = it.gyldighetsaar, opphoersaar = it.opphoersaar),
+                        Gyldighetsperiode.of(gyldighetsaar = avlopRegistrering.gyldighetsaar, opphoersaar = avlopRegistrering.opphoersaar),
                     ),
             ).takeIf { !it.erOpphoert() }
         },

--- a/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningEgenregistreringAggregering.kt
+++ b/application/src/main/kotlin/no/kartverket/matrikkel/bygning/application/models/BygningEgenregistreringAggregering.kt
@@ -62,7 +62,7 @@ fun Bruksenhet.applyEgenregistrering(egenregistrering: Egenregistrering): Brukse
                     .withGyldighetsperiode(
                         Gyldighetsperiode.of(gyldighetsaar = it.gyldighetsaar, opphoersaar = it.opphoersaar),
                     ),
-            )
+            ).takeIf { !it.erOpphoert() }
         },
         avlop = this.avlop.aggregate(bruksenhetRegistrering.avlopRegistrering) {
             Avlop(
@@ -72,7 +72,7 @@ fun Bruksenhet.applyEgenregistrering(egenregistrering: Egenregistrering): Brukse
                     .withGyldighetsperiode(
                         Gyldighetsperiode.of(gyldighetsaar = it.gyldighetsaar, opphoersaar = it.opphoersaar),
                     ),
-            )
+            ).takeIf { !it.erOpphoert() }
         },
 
         energikilder = this.energikilder.aggregate(bruksenhetRegistrering.energikildeRegistrering) { energikildeRegistrering ->
@@ -87,6 +87,7 @@ fun Bruksenhet.applyEgenregistrering(egenregistrering: Egenregistrering): Brukse
             currentEnergikilder
                 .map { energikilde -> newEnergikilderToUpdate.find { it.data == energikilde.data } ?: energikilde }
                 .plus(newEnergikilderToAdd)
+                .filter { !it.erOpphoert() }
         },
 
         oppvarming = this.oppvarming.aggregate(bruksenhetRegistrering.oppvarmingRegistrering) { oppvarmingRegistrering ->
@@ -101,6 +102,7 @@ fun Bruksenhet.applyEgenregistrering(egenregistrering: Egenregistrering): Brukse
             currentOppvarming
                 .map { oppvarming -> newOppvarmingToUpdate.find { it.data == oppvarming.data } ?: oppvarming }
                 .plus(newOppvarmingToAdd)
+                .filter { !it.erOpphoert() }
         },
 
         etasjer = this.etasjer.aggregate(

--- a/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
+++ b/application/src/test/kotlin/no/kartverket/matrikkel/bygning/application/BygningEgenregistreringAggregeringTest.kt
@@ -231,13 +231,13 @@ class BygningEgenregistreringAggregeringTest {
                         energikilde = EnergikildeKode.Elektrisitet,
                         kildemateriale = KildematerialeKode.Salgsoppgave,
                         gyldighetsaar = 2010,
-                        opphoersaar = 2015,
+                        opphoersaar = null,
                     ),
                     EnergikildeRegistrering(
                         energikilde = EnergikildeKode.AnnenEnergikilde,
                         kildemateriale = KildematerialeKode.Salgsoppgave,
                         gyldighetsaar = 2010,
-                        opphoersaar = 2015,
+                        opphoersaar = null,
                     ),
                 ),
             ),
@@ -251,13 +251,13 @@ class BygningEgenregistreringAggregeringTest {
                         energikilde = EnergikildeKode.Elektrisitet,
                         kildemateriale = KildematerialeKode.Salgsoppgave,
                         gyldighetsaar = 2015,
-                        opphoersaar = 2020,
+                        opphoersaar = null,
                     ),
                     EnergikildeRegistrering(
                         energikilde = EnergikildeKode.Fjernvarme,
                         kildemateriale = KildematerialeKode.Salgsoppgave,
                         gyldighetsaar = 2020,
-                        opphoersaar = 2022,
+                        opphoersaar = null,
                     ),
                 ),
             ),
@@ -281,7 +281,6 @@ class BygningEgenregistreringAggregeringTest {
                         prop(Felt.Energikilde::metadata).all {
                             prop(RegisterMetadata::gyldighetsperiode).all {
                                 prop(Gyldighetsperiode::gyldighetsaar).isEqualTo(Year.of(2010))
-                                prop(Gyldighetsperiode::opphoersaar).isEqualTo(Year.of(2015))
                             }
                         }
                     }
@@ -290,7 +289,6 @@ class BygningEgenregistreringAggregeringTest {
                         prop(Felt.Energikilde::metadata).all {
                             prop(RegisterMetadata::gyldighetsperiode).all {
                                 prop(Gyldighetsperiode::gyldighetsaar).isEqualTo(Year.of(2010))
-                                prop(Gyldighetsperiode::opphoersaar).isEqualTo(Year.of(2015))
                             }
                         }
                     }
@@ -306,7 +304,6 @@ class BygningEgenregistreringAggregeringTest {
                         prop(Felt.Energikilde::metadata).all {
                             prop(RegisterMetadata::gyldighetsperiode).all {
                                 prop(Gyldighetsperiode::gyldighetsaar).isEqualTo(Year.of(2015))
-                                prop(Gyldighetsperiode::opphoersaar).isEqualTo(Year.of(2020))
                             }
                         }
                     }
@@ -315,7 +312,6 @@ class BygningEgenregistreringAggregeringTest {
                         prop(Felt.Energikilde::metadata).all {
                             prop(RegisterMetadata::gyldighetsperiode).all {
                                 prop(Gyldighetsperiode::gyldighetsaar).isEqualTo(Year.of(2010))
-                                prop(Gyldighetsperiode::opphoersaar).isEqualTo(Year.of(2015))
                             }
                         }
                     }
@@ -324,7 +320,6 @@ class BygningEgenregistreringAggregeringTest {
                         prop(Felt.Energikilde::metadata).all {
                             prop(RegisterMetadata::gyldighetsperiode).all {
                                 prop(Gyldighetsperiode::gyldighetsaar).isEqualTo(Year.of(2020))
-                                prop(Gyldighetsperiode::opphoersaar).isEqualTo(Year.of(2022))
                             }
                         }
                     }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/EgenregistreringUtils.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/common/EgenregistreringUtils.kt
@@ -32,7 +32,7 @@ internal fun EgenregistreringRequest.Companion.gyldigRequest(bruksenhetId: Long 
         vannforsyning = VannforsyningKode.OffentligVannverk,
         kildemateriale = KildematerialeKode.Salgsoppgave,
         gyldighetsaar = 2010,
-        opphoersaar = 2020,
+        opphoersaar = null,
     ),
     avlopRegistrering = AvlopRegistreringRequest(
         avlop = AvlopKode.OffentligKloakk,

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BruksenhetRouteTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/intern/bygning/BruksenhetRouteTest.kt
@@ -144,7 +144,6 @@ class BruksenhetRouteTest : TestApplicationWithDb() {
                 prop(VannforsyningKodeInternResponse::data).isEqualTo(VannforsyningKode.OffentligVannverk)
                 prop(VannforsyningKodeInternResponse::metadata).all {
                     prop(RegisterMetadataInternResponse::gyldighetsaar).isEqualTo(2010)
-                    prop(RegisterMetadataInternResponse::opphoersaar).isEqualTo(2020)
                 }
             }
         }


### PR DESCRIPTION
Foreslår at vi ikke legger inn noen måte å avinstallere uten å sende med opphørsår med det første. Det vil kreve en del endringer, og jeg gjetter at vi er enige at dette gir mening å legge til i første omgang uansett