### PR TITLE
Legg til areal per etasje i eksterne responser

### DIFF
--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/berettigetinteresse/bygning/BygningBerettigetInteresseTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/berettigetinteresse/bygning/BygningBerettigetInteresseTest.kt
@@ -1,0 +1,142 @@
+package no.kartverket.matrikkel.bygning.v1.ekstern.berettigetinteresse.bygning
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.index
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import no.kartverket.matrikkel.bygning.TestApplicationWithDb
+import no.kartverket.matrikkel.bygning.application.models.kodelister.AvlopKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.EnergikildeKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.OppvarmingKode
+import no.kartverket.matrikkel.bygning.application.models.kodelister.VannforsyningKode
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.berettigetinteresse.bygning.BruksenhetBerettigetInteresseResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.berettigetinteresse.bygning.BruksenhetEtasjeBerettigetInteresseResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.berettigetinteresse.bygning.BruksenhetEtasjeBerettigetInteresseResponse.EtasjeBetegnelseBerettigetInteresseResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.berettigetinteresse.bygning.BygningBerettigetInteresseResponse
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.BruksarealRegistreringRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EgenregistreringRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EtasjeBetegnelseRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EtasjeBruksarealRegistreringRequest
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueIDPortenJWT
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueMaskinportenJWT
+import no.kartverket.matrikkel.bygning.v1.common.gyldigRequest
+import org.junit.jupiter.api.Test
+
+class BygningBerettigetInteresseTest : TestApplicationWithDb() {
+    @Test
+    fun `gitt en gyldig token med riktig scope skal tilgang gis`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val token = mockOAuthServer.issueMaskinportenJWT()
+
+        val response = client.get("/v1/berettigetinteresse/bygninger/1") {
+            bearerAuth(token.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(response.body<BygningBerettigetInteresseResponse>()).all {
+            prop(BygningBerettigetInteresseResponse::bygningId).isEqualTo(1L)
+            prop(BygningBerettigetInteresseResponse::bruksenheter).hasSize(2)
+        }
+    }
+
+    @Test
+    fun `gitt et token med feil scope skal tilgang nektes`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val token = mockOAuthServer.issueMaskinportenJWT("feil:scope")
+
+        val response = client.get("/v1/berettigetinteresse/bygninger/1") {
+            bearerAuth(token.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt et kall uten token skal tilgang nektes`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val response = client.get("/v1/berettigetinteresse/bygninger/1")
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt en egenregistrering så skal data uten metadata returneres`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val idportenToken = mockOAuthServer.issueIDPortenJWT()
+
+        val response = client.post("/v1/intern/egenregistreringer") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                EgenregistreringRequest.gyldigRequest().copy(
+                        bruksarealRegistrering = BruksarealRegistreringRequest(
+                                totaltBruksareal = 40.0,
+                                etasjeRegistreringer = listOf(
+                                        EtasjeBruksarealRegistreringRequest(
+                                                bruksareal = 30.0,
+                                                etasjebetegnelse = EtasjeBetegnelseRequest(
+                                                        etasjeplanKode = "H",
+                                                        etasjenummer = 1,
+                                                ),
+                                        ),
+                                        EtasjeBruksarealRegistreringRequest(
+                                                bruksareal = 10.0,
+                                                etasjebetegnelse = EtasjeBetegnelseRequest(
+                                                        etasjeplanKode = "L",
+                                                        etasjenummer = 1,
+                                                ),
+                                        ),
+                                ),
+                                kildemateriale = KildematerialeKode.Salgsoppgave,
+                        ),
+                ),
+            )
+            bearerAuth(idportenToken.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Created)
+
+        val maskinportenToken = mockOAuthServer.issueMaskinportenJWT()
+        val bygningResponse = client.get("/v1/berettigetinteresse/bruksenheter/1") {
+            bearerAuth(maskinportenToken.serialize())
+        }
+
+        assertThat(bygningResponse.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(bygningResponse.body<BruksenhetBerettigetInteresseResponse>()).all {
+            prop(BruksenhetBerettigetInteresseResponse::bruksenhetId).isEqualTo(1L)
+            prop(BruksenhetBerettigetInteresseResponse::etasjer).isNotNull().all {
+                index(0).all {
+                    prop(BruksenhetEtasjeBerettigetInteresseResponse::bruksareal).isEqualTo(30.0)
+                    prop(BruksenhetEtasjeBerettigetInteresseResponse::etasjeBetegnelse).all {
+                        prop(EtasjeBetegnelseBerettigetInteresseResponse::etasjeplanKode).isEqualTo("H")
+                        prop(EtasjeBetegnelseBerettigetInteresseResponse::etasjenummer).isEqualTo(1)
+                    }
+                }
+                index(1).all {
+                    prop(BruksenhetEtasjeBerettigetInteresseResponse::bruksareal).isEqualTo(10.0)
+                    prop(BruksenhetEtasjeBerettigetInteresseResponse::etasjeBetegnelse).all {
+                        prop(EtasjeBetegnelseBerettigetInteresseResponse::etasjeplanKode).isEqualTo("L")
+                        prop(EtasjeBetegnelseBerettigetInteresseResponse::etasjenummer).isEqualTo(1)
+                    }
+                }
+            }
+            prop(BruksenhetBerettigetInteresseResponse::totaltBruksareal).isEqualTo(40.0)
+            prop(BruksenhetBerettigetInteresseResponse::avlop).isEqualTo(AvlopKode.OffentligKloakk)
+            prop(BruksenhetBerettigetInteresseResponse::vannforsyning).isEqualTo(VannforsyningKode.OffentligVannverk)
+            prop(BruksenhetBerettigetInteresseResponse::energikilder).isNotNull().all {
+                index(0).isEqualTo(EnergikildeKode.Elektrisitet)
+            }
+            prop(BruksenhetBerettigetInteresseResponse::oppvarming).isNotNull().all {
+                index(0).isEqualTo(OppvarmingKode.Elektrisk)
+            }
+        }
+    }
+}

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/medpersondata/bygning/BygningMedPersondataTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/medpersondata/bygning/BygningMedPersondataTest.kt
@@ -2,14 +2,35 @@ package no.kartverket.matrikkel.bygning.v1.ekstern.medpersondata.bygning
 
 import assertk.all
 import assertk.assertThat
-import assertk.assertions.*
+import assertk.assertions.hasSize
+import assertk.assertions.index
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import no.kartverket.matrikkel.bygning.TestApplicationWithDb
+import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.BruksenhetMedPersondataResponse
 import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.BygningMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.FeltMedPersondataResponse.AvlopKodeMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.FeltMedPersondataResponse.BruksarealMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.FeltMedPersondataResponse.BruksenhetEtasjerMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.FeltMedPersondataResponse.BruksenhetEtasjerMedPersondataResponse.BruksenhetEtasjeMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.FeltMedPersondataResponse.BruksenhetEtasjerMedPersondataResponse.EtasjeBetegnelseMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.FeltMedPersondataResponse.EnergikildeMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.FeltMedPersondataResponse.OppvarmingMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.FeltMedPersondataResponse.VannforsyningKodeMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.medpersondata.bygning.RegisterMetadataMedPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.BruksarealRegistreringRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EgenregistreringRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EtasjeBetegnelseRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EtasjeBruksarealRegistreringRequest
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueIDPortenJWT
 import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueMaskinportenJWT
+import no.kartverket.matrikkel.bygning.v1.common.gyldigRequest
 import org.junit.jupiter.api.Test
 
 class BygningMedPersondataTest : TestApplicationWithDb() {
@@ -48,5 +69,102 @@ class BygningMedPersondataTest : TestApplicationWithDb() {
         val response = client.get("/v1/medpersondata/bygninger/1")
 
         assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt en egenregistrering så skal data uten persondata returneres`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val idportenToken = mockOAuthServer.issueIDPortenJWT()
+
+        val response = client.post("/v1/intern/egenregistreringer") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                EgenregistreringRequest.gyldigRequest().copy(
+                    bruksarealRegistrering = BruksarealRegistreringRequest(
+                        totaltBruksareal = 40.0,
+                        etasjeRegistreringer = listOf(
+                            EtasjeBruksarealRegistreringRequest(
+                                bruksareal = 30.0,
+                                etasjebetegnelse = EtasjeBetegnelseRequest(
+                                    etasjeplanKode = "H",
+                                    etasjenummer = 1,
+                                ),
+                            ),
+                            EtasjeBruksarealRegistreringRequest(
+                                bruksareal = 10.0,
+                                etasjebetegnelse = EtasjeBetegnelseRequest(
+                                    etasjeplanKode = "L",
+                                    etasjenummer = 1,
+                                ),
+                            ),
+                        ),
+                        kildemateriale = KildematerialeKode.Salgsoppgave,
+                    ),
+                ),
+            )
+            bearerAuth(idportenToken.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Created)
+
+        val maskinportenToken = mockOAuthServer.issueMaskinportenJWT()
+        val bygningResponse = client.get("/v1/medpersondata/bruksenheter/1") {
+            bearerAuth(maskinportenToken.serialize())
+        }
+
+        assertThat(bygningResponse.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(bygningResponse.body<BruksenhetMedPersondataResponse>()).all {
+            prop(BruksenhetMedPersondataResponse::bruksenhetId).isEqualTo(1L)
+            prop(BruksenhetMedPersondataResponse::etasjer).isNotNull().all {
+                prop(BruksenhetEtasjerMedPersondataResponse::data).all {
+                    index(0).all {
+                        prop(BruksenhetEtasjeMedPersondataResponse::bruksareal).isEqualTo(30.0)
+                        prop(BruksenhetEtasjeMedPersondataResponse::etasjeBetegnelse).all {
+                            prop(EtasjeBetegnelseMedPersondataResponse::etasjeplanKode).isEqualTo("H")
+                            prop(EtasjeBetegnelseMedPersondataResponse::etasjenummer).isEqualTo(1)
+                        }
+                    }
+                    index(1).all {
+                        prop(BruksenhetEtasjeMedPersondataResponse::bruksareal).isEqualTo(10.0)
+                        prop(BruksenhetEtasjeMedPersondataResponse::etasjeBetegnelse).all {
+                            prop(EtasjeBetegnelseMedPersondataResponse::etasjeplanKode).isEqualTo("L")
+                            prop(EtasjeBetegnelseMedPersondataResponse::etasjenummer).isEqualTo(1)
+                        }
+                    }
+                }
+                prop(BruksenhetEtasjerMedPersondataResponse::metadata).all {
+                    prop(RegisterMetadataMedPersondataResponse::registrertAv).isEqualTo("66860475309")
+                }
+            }
+            prop(BruksenhetMedPersondataResponse::totaltBruksareal).isNotNull().all {
+                prop(BruksarealMedPersondataResponse::metadata).all {
+                    prop(RegisterMetadataMedPersondataResponse::registrertAv).isEqualTo("66860475309")
+                }
+            }
+            prop(BruksenhetMedPersondataResponse::vannforsyning).isNotNull().all {
+                prop(VannforsyningKodeMedPersondataResponse::metadata).all {
+                    prop(RegisterMetadataMedPersondataResponse::registrertAv).isEqualTo("66860475309")
+                }
+            }
+            prop(BruksenhetMedPersondataResponse::avlop).isNotNull().all {
+                prop(AvlopKodeMedPersondataResponse::metadata).all {
+                    prop(RegisterMetadataMedPersondataResponse::registrertAv).isEqualTo("66860475309")
+                }
+            }
+            prop(BruksenhetMedPersondataResponse::energikilder).isNotNull().all {
+                index(0).isNotNull().all {
+                    prop(EnergikildeMedPersondataResponse::metadata).all {
+                        prop(RegisterMetadataMedPersondataResponse::registrertAv).isEqualTo("66860475309")
+                    }
+                }
+            }
+            prop(BruksenhetMedPersondataResponse::oppvarming).isNotNull().all {
+                index(0).isNotNull().all {
+                    prop(OppvarmingMedPersondataResponse::metadata).all {
+                        prop(RegisterMetadataMedPersondataResponse::registrertAv).isEqualTo("66860475309")
+                    }
+                }
+            }
+        }
     }
 }

--- a/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/utenpersondata/bygning/BygningUtenPersondataTest.kt
+++ b/web/src/integrationTest/kotlin/no/kartverket/matrikkel/bygning/v1/ekstern/utenpersondata/bygning/BygningUtenPersondataTest.kt
@@ -1,0 +1,171 @@
+package no.kartverket.matrikkel.bygning.v1.ekstern.utenpersondata.bygning
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.index
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import no.kartverket.matrikkel.bygning.TestApplicationWithDb
+import no.kartverket.matrikkel.bygning.application.models.kodelister.KildematerialeKode
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.berettigetinteresse.bygning.BruksenhetEtasjeBerettigetInteresseResponse.EtasjeBetegnelseBerettigetInteresseResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.BruksenhetUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.BygningUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.AvlopKodeUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.BruksarealUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.BruksenhetEtasjerUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.BruksenhetEtasjerUtenPersondataResponse.BruksenhetEtasjeUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.BruksenhetEtasjerUtenPersondataResponse.EtasjeBetegnelseUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.EnergikildeUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.OppvarmingUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.FeltUtenPersondataResponse.VannforsyningKodeUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.ekstern.utenpersondata.bygning.RegisterMetadataUtenPersondataResponse
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.BruksarealRegistreringRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EgenregistreringRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EtasjeBetegnelseRequest
+import no.kartverket.matrikkel.bygning.routes.v1.intern.egenregistrering.EtasjeBruksarealRegistreringRequest
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueIDPortenJWT
+import no.kartverket.matrikkel.bygning.v1.common.MockOAuth2ServerExtensions.Companion.issueMaskinportenJWT
+import no.kartverket.matrikkel.bygning.v1.common.gyldigRequest
+import org.junit.jupiter.api.Test
+
+class BygningUtenPersondataTest : TestApplicationWithDb() {
+    @Test
+    fun `gitt en gyldig token med riktig scope skal tilgang gis`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val token = mockOAuthServer.issueMaskinportenJWT()
+
+        val response = client.get("/v1/utenpersondata/bygninger/1") {
+            bearerAuth(token.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(response.body<BygningUtenPersondataResponse>()).all {
+            prop(BygningUtenPersondataResponse::bygningId).isEqualTo(1L)
+            prop(BygningUtenPersondataResponse::bruksenheter).hasSize(2)
+        }
+    }
+
+    @Test
+    fun `gitt et token med feil scope skal tilgang nektes`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val token = mockOAuthServer.issueMaskinportenJWT("feil:scope")
+
+        val response = client.get("/v1/utenpersondata/bygninger/1") {
+            bearerAuth(token.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt et kall uten token skal tilgang nektes`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+
+        val response = client.get("/v1/utenpersondata/bygninger/1")
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `gitt en egenregistrering så skal data uten persondata returneres`() = testApplication {
+        val client = mainModuleWithDatabaseEnvironmentAndClient()
+        val idportenToken = mockOAuthServer.issueIDPortenJWT()
+
+        val response = client.post("/v1/intern/egenregistreringer") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                EgenregistreringRequest.gyldigRequest().copy(
+                    bruksarealRegistrering = BruksarealRegistreringRequest(
+                        totaltBruksareal = 40.0,
+                        etasjeRegistreringer = listOf(
+                            EtasjeBruksarealRegistreringRequest(
+                                bruksareal = 30.0,
+                                etasjebetegnelse = EtasjeBetegnelseRequest(
+                                    etasjeplanKode = "H",
+                                    etasjenummer = 1,
+                                ),
+                            ),
+                            EtasjeBruksarealRegistreringRequest(
+                                bruksareal = 10.0,
+                                etasjebetegnelse = EtasjeBetegnelseRequest(
+                                    etasjeplanKode = "L",
+                                    etasjenummer = 1,
+                                ),
+                            ),
+                        ),
+                        kildemateriale = KildematerialeKode.Salgsoppgave,
+                    ),
+                ),
+            )
+            bearerAuth(idportenToken.serialize())
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Created)
+
+        val maskinportenToken = mockOAuthServer.issueMaskinportenJWT()
+        val bygningResponse = client.get("/v1/utenpersondata/bruksenheter/1") {
+            bearerAuth(maskinportenToken.serialize())
+        }
+
+        assertThat(bygningResponse.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(bygningResponse.body<BruksenhetUtenPersondataResponse>()).all {
+            prop(BruksenhetUtenPersondataResponse::bruksenhetId).isEqualTo(1L)
+            prop(BruksenhetUtenPersondataResponse::etasjer).isNotNull().all {
+                prop(BruksenhetEtasjerUtenPersondataResponse::data).all {
+                    index(0).all {
+                        prop(BruksenhetEtasjeUtenPersondataResponse::bruksareal).isEqualTo(30.0)
+                        prop(BruksenhetEtasjeUtenPersondataResponse::etasjeBetegnelse).all {
+                            prop(EtasjeBetegnelseUtenPersondataResponse::etasjeplanKode).isEqualTo("H")
+                            prop(EtasjeBetegnelseUtenPersondataResponse::etasjenummer).isEqualTo(1)
+                        }
+                    }
+                    index(1).all {
+                        prop(BruksenhetEtasjeUtenPersondataResponse::bruksareal).isEqualTo(10.0)
+                        prop(BruksenhetEtasjeUtenPersondataResponse::etasjeBetegnelse).all {
+                            prop(EtasjeBetegnelseUtenPersondataResponse::etasjeplanKode).isEqualTo("L")
+                            prop(EtasjeBetegnelseUtenPersondataResponse::etasjenummer).isEqualTo(1)
+                        }
+                    }
+                }
+                prop(BruksenhetEtasjerUtenPersondataResponse::metadata).all {
+                    prop(RegisterMetadataUtenPersondataResponse::kildemateriale).isEqualTo(KildematerialeKode.Salgsoppgave)
+                }
+            }
+            prop(BruksenhetUtenPersondataResponse::totaltBruksareal).isNotNull().all {
+                prop(BruksarealUtenPersondataResponse::metadata).all {
+                    prop(RegisterMetadataUtenPersondataResponse::kildemateriale).isEqualTo(KildematerialeKode.Salgsoppgave)
+                }
+            }
+            prop(BruksenhetUtenPersondataResponse::vannforsyning).isNotNull().all {
+                prop(VannforsyningKodeUtenPersondataResponse::metadata).all {
+                    prop(RegisterMetadataUtenPersondataResponse::kildemateriale).isEqualTo(KildematerialeKode.Salgsoppgave)
+                }
+            }
+            prop(BruksenhetUtenPersondataResponse::avlop).isNotNull().all {
+                prop(AvlopKodeUtenPersondataResponse::metadata).all {
+                    prop(RegisterMetadataUtenPersondataResponse::kildemateriale).isEqualTo(KildematerialeKode.Selvrapportert)
+                }
+            }
+            prop(BruksenhetUtenPersondataResponse::energikilder).isNotNull().all {
+                index(0).isNotNull().all {
+                    prop(EnergikildeUtenPersondataResponse::metadata).all {
+                        prop(RegisterMetadataUtenPersondataResponse::kildemateriale).isEqualTo(KildematerialeKode.Selvrapportert)
+                    }
+                }
+            }
+            prop(BruksenhetUtenPersondataResponse::oppvarming).isNotNull().all {
+                index(0).isNotNull().all {
+                    prop(OppvarmingUtenPersondataResponse::metadata).all {
+                        prop(RegisterMetadataUtenPersondataResponse::kildemateriale).isEqualTo(KildematerialeKode.Selvrapportert)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/berettigetinteresse/bygning/BygningBerettigetInteresseResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/berettigetinteresse/bygning/BygningBerettigetInteresseResponse.kt
@@ -20,12 +20,18 @@ data class BruksenhetBerettigetInteresseResponse(
     val bruksenhetId: Long,
     val byggeaar: Int?,
     val totaltBruksareal: Double?,
+    val etasjer: List<BruksenhetEtasjeBerettigetInteresseResponse>?,
     val vannforsyning: VannforsyningKode?,
     val avlop: AvlopKode?,
     val energikilder: List<EnergikildeKode>?,
     val oppvarming: List<OppvarmingKode>?,
 )
 
+@Serializable
+data class BruksenhetEtasjeBerettigetInteresseResponse(
+    val etasjeBetegnelse: String,
+    val bruksareal: Double,
+)
 
 fun Bygning.toBygningBerettigetInteresseResponse(): BygningBerettigetInteresseResponse = BygningBerettigetInteresseResponse(
     bygningId = bygningBubbleId.value,
@@ -39,6 +45,12 @@ fun Bruksenhet.toBruksenhetBerettigetInteresseResponse(): BruksenhetBerettigetIn
     bruksenhetId = this.bruksenhetBubbleId.value,
     byggeaar = this.byggeaar.egenregistrert?.data,
     totaltBruksareal = this.totaltBruksareal.egenregistrert?.data,
+    etasjer = this.etasjer.egenregistrert?.data?.map {
+        BruksenhetEtasjeBerettigetInteresseResponse(
+            etasjeBetegnelse = it.etasjebetegnelse.toString(),
+            bruksareal = it.bruksareal,
+        )
+    },
     vannforsyning = this.vannforsyning.egenregistrert?.data,
     avlop = this.avlop.egenregistrert?.data,
     energikilder = this.energikilder.egenregistrert?.map { it.data },

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/berettigetinteresse/bygning/BygningBerettigetInteresseResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/berettigetinteresse/bygning/BygningBerettigetInteresseResponse.kt
@@ -29,9 +29,15 @@ data class BruksenhetBerettigetInteresseResponse(
 
 @Serializable
 data class BruksenhetEtasjeBerettigetInteresseResponse(
-    val etasjeBetegnelse: String,
+    val etasjeBetegnelse: EtasjeBetegnelseBerettigetInteresseResponse,
     val bruksareal: Double,
-)
+) {
+    @Serializable
+    data class EtasjeBetegnelseBerettigetInteresseResponse(
+        val etasjeplanKode: String,
+        val etasjenummer: Int,
+    )
+}
 
 fun Bygning.toBygningBerettigetInteresseResponse(): BygningBerettigetInteresseResponse = BygningBerettigetInteresseResponse(
     bygningId = bygningBubbleId.value,
@@ -47,7 +53,10 @@ fun Bruksenhet.toBruksenhetBerettigetInteresseResponse(): BruksenhetBerettigetIn
     totaltBruksareal = this.totaltBruksareal.egenregistrert?.data,
     etasjer = this.etasjer.egenregistrert?.data?.map {
         BruksenhetEtasjeBerettigetInteresseResponse(
-            etasjeBetegnelse = it.etasjebetegnelse.toString(),
+            etasjeBetegnelse = BruksenhetEtasjeBerettigetInteresseResponse.EtasjeBetegnelseBerettigetInteresseResponse(
+                etasjeplanKode = it.etasjebetegnelse.etasjeplanKode.toString(),
+                etasjenummer = it.etasjebetegnelse.etasjenummer.loepenummer,
+            ),
             bruksareal = it.bruksareal,
         )
     },

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/medpersondata/bygning/BygningMedPersondataResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/medpersondata/bygning/BygningMedPersondataResponse.kt
@@ -64,8 +64,14 @@ sealed interface FeltMedPersondataResponse<T> {
     ) : FeltMedPersondataResponse<List<BruksenhetEtasjeMedPersondataResponse>> {
         @Serializable
         data class BruksenhetEtasjeMedPersondataResponse(
-            val etasjeBetegnelse: String,
+            val etasjeBetegnelse: EtasjeBetegnelseMedPersondataResponse,
             val bruksareal: Double
+        )
+
+        @Serializable
+        data class EtasjeBetegnelseMedPersondataResponse(
+            val etasjeplanKode: String,
+            val etasjenummer: Int,
         )
     }
 
@@ -158,7 +164,10 @@ private fun Felt.BruksenhetEtasjer.toEtasjeMedPersondataResponse(): BruksenhetEt
     BruksenhetEtasjerMedPersondataResponse(
         data = this.data.map {
             BruksenhetEtasjeMedPersondataResponse(
-                etasjeBetegnelse = it.etasjebetegnelse.toString(),
+                etasjeBetegnelse = BruksenhetEtasjerMedPersondataResponse.EtasjeBetegnelseMedPersondataResponse(
+                    etasjeplanKode = it.etasjebetegnelse.etasjeplanKode.toString(),
+                    etasjenummer = it.etasjebetegnelse.etasjenummer.loepenummer,
+                ),
                 bruksareal = it.bruksareal,
             )
         },

--- a/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/utenpersondata/bygning/BygningUtenPersondataResponse.kt
+++ b/web/src/main/kotlin/no/kartverket/matrikkel/bygning/routes/v1/ekstern/utenpersondata/bygning/BygningUtenPersondataResponse.kt
@@ -64,8 +64,14 @@ sealed interface FeltUtenPersondataResponse<T> {
     ) : FeltUtenPersondataResponse<List<BruksenhetEtasjeUtenPersondataResponse>> {
         @Serializable
         data class BruksenhetEtasjeUtenPersondataResponse(
-            val etasjeBetegnelse: String,
+            val etasjeBetegnelse: EtasjeBetegnelseUtenPersondataResponse,
             val bruksareal: Double
+        )
+
+        @Serializable
+        data class EtasjeBetegnelseUtenPersondataResponse (
+            val etasjeplanKode: String,
+            val etasjenummer: Int
         )
     }
 
@@ -153,7 +159,10 @@ private fun Felt.BruksenhetEtasjer.toEtasjeUtenPersondataResponse(): BruksenhetE
     BruksenhetEtasjerUtenPersondataResponse(
         data = this.data.map {
             BruksenhetEtasjeUtenPersondataResponse(
-                etasjeBetegnelse = it.etasjebetegnelse.toString(),
+                etasjeBetegnelse = BruksenhetEtasjerUtenPersondataResponse.EtasjeBetegnelseUtenPersondataResponse(
+                    etasjeplanKode = it.etasjebetegnelse.etasjeplanKode.toString(),
+                    etasjenummer = it.etasjebetegnelse.etasjenummer.loepenummer,
+                ),
                 bruksareal = it.bruksareal,
             )
         },


### PR DESCRIPTION
Får ikke brukt hjelpefunksjonene da etasje oppfører seg som gammel oppvarming/energikilder. Siden det bare gjelder ett felt så tenker jeg det er greit at det bare har sine egne mappingfunksjoner.